### PR TITLE
scitos_common: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6450,6 +6450,22 @@ repositories:
       url: https://github.com/ipa320/schunk_modular_robotics.git
       version: hydro_dev
     status: developed
+  scitos_common:
+    release:
+      packages:
+      - calibrate_chest
+      - scitos_common
+      - scitos_description
+      - scitos_msgs
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/scitos_common.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/strands-project/scitos_common.git
+      version: hydro-devel
+    status: developed
   scriptable_monitoring:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_common` to `0.0.1-0`:
- upstream repository: https://github.com/strands-project/scitos_common.git
- release repository: https://github.com/strands-project-releases/scitos_common.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## calibrate_chest

```
* Removed my error.
* Renamed ros_datacentre to mongodb_store
  This simply bulk replaces all ros_datacentre strings to mongodb_store strings inside files and also in file names.
  Needs strands-project/ros_datacentre#76 <https://github.com/strands-project/ros_datacentre/issues/76> to me merged first.
* Made call unambiguous. Needs testing.
* Renamed ros_datacentre to mongodb_store
  This simply bulk replaces all ros_datacentre strings to mongodb_store strings inside files and also in file names.
  Needs strands-project/ros_datacentre#76 <https://github.com/strands-project/ros_datacentre/issues/76> to me merged first.
* Fixed misspelling of ros_datacentre in package.xml
* Still some wrong entries of strands_datacentre
* Merge branch 'hydro-devel' into groovy-devel
  Conflicts:
  calibrate_chest/CMakeLists.txt
  calibrate_chest/package.xml
* Switched strands_datacentre to ros_datacentre in here.
* [calibrate_chest] remove version number
* [calibrate_chest] pcl version
* Added a proper desciption of what the package does
* Fixed a bug where all of the dependencies on the datacentre where not defined properly which made parallell builds fail and filled out package.xml
* Updated the position of the camera
* Got the publisher working now, running it in scitos_state_publisher launch file for ten seconds to update urdf with latest calibration parameters
* Added broadcaster of chest clibration, does not really work
* Added comments and cleanup
* Added storage of calibration parameters in strands datacentre
* The angle in the urdf model seems to be right the other way
* Added chest calibratioN
* Contributors: Christian Dondrup, Nick Hawes, Nils Bore, Rares Ambrus, cburbridge, cdondrup
```
## scitos_common

```
* added scitos_msgs to metapackage
* changed version strings to match convention, fixes a problem to use catkin_make on these packages
* added scitos urdf to scitos_description, added scitos_common as meta-package
* Contributors: Chris, Lars Kunze, Marc Hanheide
```
## scitos_description

```
* Adding Machine tag to scitos_state_publisher.launch
* Adding robot_pose_publish to scitos_state_publisher.launch
  /robot_pose topic is needed by visual_charging node and waypoint_patroller
* Updated the position of the camera
* Got the publisher working now, running it in scitos_state_publisher launch file for ten seconds to update urdf with latest calibration parameters
* Added broadcaster of chest clibration, does not really work
* Fixed the camera position forward direction
* Modified chest camera frame in sideways direction
* Added chest camera in urdf model
* using correct frames for xtion
* Normals of faces repared
* removed inertia sections; added xtion frames for head camera
* using new model, adding in head transformations..
* Merge branch 'master' of https://github.com/cburbridge/scitos_common into head_transforms
  Conflicts:
  scitos_description/urdf/scitos.xacro
* supporting background images deleted from meshes
* adding new model and xtion frames
* Adding meshes to new detaily robot body scitos_1 and frame around head.
* added xtion frames to urdf
* initial transforms in place
* tidying mesh file names and removing old meshes
* improve camera position, use new link model.
* using the new and accurate ptu transforms and model
* Improving pantilt unit - added 4th part
* Pantilt unit with newly defined frames.
* removing unused original urdf; now use xacro
* Meshes for pantilt unit added. 0 is the motor for z-axis, 1 is the motor for y-axis, 2 is the top part
* allowing for per robot calibration
* removing double filename
* moving transforms to easy edit place
* set xtion link from correct to match openni standard
* update urdf to include xtion and pantilt
* Xtion camera mesh
* added robot mesh
* changed version strings to match convention, fixes a problem to use catkin_make on these packages
* added launch file for loading the scitos urdf and using the robot_state_publisher
* added scitos urdf to scitos_description, added scitos_common as meta-package
* Contributors: Chris Burbridge, Jaime Pulido Fentanes, Lars Kunze, Lenka Mudrova, Marc Hanheide, Nils Bore, Rares Ambrus, cburbridge
```
## scitos_msgs

```
* Adding bumper state
* motor status message type
* headlights message format
* removed headed
* New message type for controlling the light status
* Preparing to move scitos_msgs to common
* Contributors: Chris, Chris Burbridge
```
