### PR TITLE
strands_morse: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6916,6 +6916,17 @@ repositories:
       type: git
       url: https://github.com/srv/stereo_slam.git
       version: hydro
+  strands_morse:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_morse.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/strands-project/strands_morse.git
+      version: hydro-devel
+    status: developed
   swiftnav:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## strands_morse

```
* fixed rosdeps
* Contributors: Marc Hanheide
```
