### PR TITLE
scitos_common: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6493,7 +6493,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_common.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_common` to `0.0.4-0`:
- upstream repository: https://github.com/strands-project/scitos_common.git
- release repository: https://github.com/strands-project-releases/scitos_common.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.3-0`
## calibrate_chest

```
* included install target
* Contributors: Marc Hanheide
```
## scitos_common
- No changes
## scitos_description
- No changes
## scitos_msgs
- No changes
