### PR TITLE
bayes_tracking: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -322,6 +322,17 @@ repositories:
       url: https://github.com/RethinkRobotics/baxter_tools.git
       version: master
     status: developed
+  bayes_tracking:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/bayes_tracking.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/LCAS/bayestracking.git
+      version: master
+    status: developed
   bfl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `bayes_tracking` to `1.0.1-0`:
- upstream repository: https://github.com/LCAS/bayestracking.git
- release repository: https://github.com/strands-project-releases/bayes_tracking.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## bayes_tracking

```
* Merge pull request #4 <https://github.com/cdondrup/bayestracking/issues/4> from cdondrup/master
  Renamed bayestracking to bayes_tracking to comply with ros naming conventions.
* Renamed bayestracking to bayes_tracking to comply with ros naming conventions.
* Merge pull request #2 <https://github.com/cdondrup/bayestracking/issues/2> from cdondrup/master
  Adding optional catkin build
* 

    * Enabling normal cmake build if catkin is not available.
    * Updated package.xml and create install targets for ROS release
    * Refactored README to markdown

* Refactored bayestracking library to be a catkin package
  Created a cleaner file structure by seperating the src from the include files.
* Update README
* Update README
* Now generates cmake config files to enable usage of find_package
* Added the creation of a pkg-config file to make the library easier to use.
* PFilter not working right now in simple_tracking.cpp, but all other tested filters (UKF and EKF) worked very well
* fixed size_t uint issue
* compiles now (but simple_tracking example still gives errors)
* initial import form package
* Contributors: Christian Dondrup, Marc Hanheide
```
