### PR TITLE
bayes_tracking: 1.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -327,7 +327,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/bayes_tracking.git
-      version: 1.0.1-0
+      version: 1.0.2-0
     source:
       type: git
       url: https://github.com/LCAS/bayestracking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bayes_tracking` to `1.0.2-0`:
- upstream repository: https://github.com/LCAS/bayestracking.git
- release repository: https://github.com/strands-project-releases/bayes_tracking.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.1-0`
## bayes_tracking

```
* Adding boost as a build an run dependency.
* Changing Licence to GPL
* Contributors: Christian Dondrup
```
