### PR TITLE
mongodb_store: 0.0.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3591,7 +3591,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.0.3-0
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.0.3-1`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.3-0`
## mongodb_log

```
* Renamed rosparams datacentre_ to mongodb_.
  Fixes #69 <https://github.com/strands-project/ros_datacentre/issues/69>
* Renamed ros_datacentre to mongodb_store for to fix #69 <https://github.com/strands-project/ros_datacentre/issues/69>.
* Contributors: Nick Hawes
```
## mongodb_store

```
* Renamed rosparams datacentre_ to mongodb_.
  Fixes #69 <https://github.com/strands-project/ros_datacentre/issues/69>
* More renaming to mongodb_store
* Renamed launch file.
* Renamed ros_datacentre to mongodb_store for to fix #69 <https://github.com/strands-project/ros_datacentre/issues/69>.
* Contributors: Nick Hawes
```
## mongodb_store_cpp_client

```
* Renamed rosparams datacentre_ to mongodb_.
  Fixes #69 <https://github.com/strands-project/ros_datacentre/issues/69>
* Renamed ros_datacentre to mongodb_store for to fix #69 <https://github.com/strands-project/ros_datacentre/issues/69>.
* Contributors: Nick Hawes
```
## mongodb_store_msgs

```
* Renamed ros_datacentre to mongodb_store for to fix #69 <https://github.com/strands-project/ros_datacentre/issues/69>.
* Contributors: Nick Hawes
```
