### PR TITLE
bayes_tracking: 1.0.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -346,7 +346,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/bayes_tracking.git
-      version: 1.0.3-0
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/LCAS/bayestracking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bayes_tracking` to `1.0.3-1`:
- upstream repository: https://github.com/LCAS/bayestracking.git
- release repository: https://github.com/strands-project-releases/bayes_tracking.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.3-0`
## bayes_tracking

```
* "Fixing" the missing JPDA
  The option of using only JPDA as an association algorithm was a relic from past development and is not supported anymore.
  This change just comments the JPDA in the enum, preventing people from trying to use it.
* Using the correct licence now.
* 1.0.2
* Updated changelog for 1.0.2
* Adding boost as a build an run dependency.
* 1.0.1
* Reverting the version number increase.
* Merge pull request #5 <https://github.com/LCAS/bayestracking/issues/5> from cdondrup/master
  Release preparations
* Contributors: Christian Dondrup
```
