### PR TITLE
scitos_common: 0.0.4-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -346,7 +346,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/bayes_tracking.git
-      version: 1.0.3-1
+      version: 1.0.3-0
     source:
       type: git
       url: https://github.com/LCAS/bayestracking.git
@@ -6722,7 +6722,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_common.git
-      version: 0.0.4-0
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/strands-project/scitos_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_common` to `0.0.4-1`:
- upstream repository: https://github.com/strands-project/scitos_common.git
- release repository: https://github.com/strands-project-releases/scitos_common.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.4-0`
## calibrate_chest

```
* included install target
* Contributors: Marc Hanheide
```
## scitos_common
- No changes
## scitos_description
- No changes
## scitos_msgs
- No changes
