### PR TITLE
mongodb_store: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2390,6 +2390,22 @@ repositories:
       url: https://github.com/RobotWebTools/mjpeg_server.git
       version: develop
     status: maintained
+  mongodb_store:
+    release:
+      packages:
+      - mongodb_log
+      - mongodb_store
+      - mongodb_store_cpp_client
+      - mongodb_store_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/mongodb_store.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/strands-project/mongodb_store.git
+      version: hydro-devel
+    status: developed
   moveit_commander:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## mongodb_log

```
* Renamed rosparams datacentre_ to mongodb_.
  Fixes #69 <https://github.com/strands-project/ros_datacentre/issues/69>
* Renamed ros_datacentre to mongodb_store for to fix #69 <https://github.com/strands-project/ros_datacentre/issues/69>.
* Contributors: Nick Hawes
```
## mongodb_store

```
* Renamed rosparams datacentre_ to mongodb_.
  Fixes #69 <https://github.com/strands-project/ros_datacentre/issues/69>
* More renaming to mongodb_store
* Renamed launch file.
* Renamed ros_datacentre to mongodb_store for to fix #69 <https://github.com/strands-project/ros_datacentre/issues/69>.
* Contributors: Nick Hawes
```
## mongodb_store_cpp_client

```
* Renamed rosparams datacentre_ to mongodb_.
  Fixes #69 <https://github.com/strands-project/ros_datacentre/issues/69>
* Renamed ros_datacentre to mongodb_store for to fix #69 <https://github.com/strands-project/ros_datacentre/issues/69>.
* Contributors: Nick Hawes
```
## mongodb_store_msgs

```
* Renamed ros_datacentre to mongodb_store for to fix #69 <https://github.com/strands-project/ros_datacentre/issues/69>.
* Contributors: Nick Hawes
```
