### PR TITLE
mongodb_store: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3591,7 +3591,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.0.3-1
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.0.4-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `0.0.3-1`
## mongodb_log

```
* added libssl and libcrypto for ubuntu distros where this is needed due to the static nature of the libmongoclient.a
* Contributors: Marc Hanheide
```
## mongodb_store

```
* added mongod
* Add son_manipulator import
* Added test mode to mongodb_server.py
  This generates a random port to listen on and creates a corresponding dbpath under /tmp. The port is tested to see if it's free before it's used.
  This closes #77 <https://github.com/strands-project/mongodb_store/issues/77> and #75 <https://github.com/strands-project/mongodb_store/issues/75>.
* Contributors: Chris Burbridge, Marc Hanheide, Nick Hawes
```
## mongodb_store_cpp_client

```
* added libssl and libcrypto for ubuntu distros where this is needed due to the static nature of the libmongoclient.a
* Added author email and license.
* Added test mode to mongodb_server.py
  This generates a random port to listen on and creates a corresponding dbpath under /tmp. The port is tested to see if it's free before it's used.
  This closes #77 <https://github.com/strands-project/mongodb_store/issues/77> and #75 <https://github.com/strands-project/mongodb_store/issues/75>.
* Contributors: Marc Hanheide, Nick Hawes
```
## mongodb_store_msgs
- No changes
