### PR TITLE
Added robblog to the distribution to start testing on jenkins.

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5427,6 +5427,11 @@ repositories:
       url: https://github.com/robotican/ric.git
       version: master
     status: maintained
+  robblog:
+      source:
+        type: git
+        url: https://github.com/strands-project/robblog.git
+        version: hydro-devel
   robot_localization:
     doc:
       type: git

--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5428,10 +5428,10 @@ repositories:
       version: master
     status: maintained
   robblog:
-      source:
-        type: git
-        url: https://github.com/strands-project/robblog.git
-        version: hydro-devel
+    source:
+      type: git
+      url: https://github.com/strands-project/robblog.git
+      version: hydro-devel
   robot_localization:
     doc:
       type: git


### PR DESCRIPTION
This will fail initially because rosdeps are missing, but these have been requested: https://github.com/ros/rosdistro/pull/5692
