### PR TITLE
sicks300: 1.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7239,6 +7239,17 @@ repositories:
       url: https://github.com/uos/sick_tim.git
       version: hydro_catkin
     status: developed
+  sicks300:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/sicks300.git
+      version: 1.0.1-0
+    source:
+      type: git
+      url: https://github.com/strands-project/sicks300.git
+      version: master
+    status: maintained
   sicktoolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sicks300` to `1.0.1-0`:
- upstream repository: https://github.com/strands-project/sicks300.git
- release repository: https://github.com/strands-project-releases/sicks300.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## sicks300

```
* Merge pull request #2 <https://github.com/strands-project/sicks300/issues/2> from larics/master
  Catkinized the package
* Updated CMakeLists.txt and package.xml.
* Catkinized the package.
* Update README.md
* Fixed typo and added more explicit credits.
* Modified description and authors in manifest file
* Update README.md
* Create README.md
* 

    * Adapted original implementation to support both the old (v.1.02) and the new (v.1.03) protocols for continuous data output of the SICK S300 Professional
    * Fixed a bug which caused the header start to be off (this caused unnecessary CRC failures)
    * Adapted copyrights/license stuff

* 
* 
* 
* 
* Contributors: Damjan Miklic, Dimitri Bohlender, dbohlender, torstenfiolka
* Merge pull request #2 <https://github.com/strands-project/sicks300/issues/2> from larics/master
  Catkinized the package
* Updated CMakeLists.txt and package.xml.
* Catkinized the package.
* Update README.md
* Fixed typo and added more explicit credits.
* Modified description and authors in manifest file
* Update README.md
* Create README.md
* 

    * Adapted original implementation to support both the old (v.1.02) and the new (v.1.03) protocols for continuous data output of the SICK S300 Professional
    * Fixed a bug which caused the header start to be off (this caused unnecessary CRC failures)
    * Adapted copyrights/license stuff

* 
* 
* 
* 
* Contributors: Damjan Miklic, Dimitri Bohlender, dbohlender, torstenfiolka
```
