### PR TITLE
sicks300: 1.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7244,7 +7244,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/sicks300.git
-      version: 1.0.3-0
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/strands-project/sicks300.git


### PR DESCRIPTION
Increasing version of package(s) in repository `sicks300` to `1.0.4-0`:
- upstream repository: https://github.com/strands-project/sicks300.git
- release repository: https://github.com/strands-project-releases/sicks300.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `1.0.3-0`
## sicks300

```
* added unistd.h for gcc
* Contributors: Marc Hanheide
```
