### PR TITLE
sicks300: 1.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4867,6 +4867,17 @@ repositories:
       url: https://github.com/uos/sick_tim.git
       version: indigo
     status: developed
+  sicks300:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/sicks300.git
+      version: 1.0.4-0
+    source:
+      type: git
+      url: https://github.com/strands-project/sicks300.git
+      version: master
+    status: maintained
   sicktoolbox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `sicks300` to `1.0.4-0`:
- upstream repository: https://github.com/strands-project/sicks300.git
- release repository: https://github.com/strands-project-releases/sicks300.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## sicks300

```
* added unistd.h for gcc
* Contributors: Marc Hanheide
```
