### PR TITLE
scitos_apps: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7003,10 +7003,23 @@ repositories:
       version: hydro_dev
     status: developed
   scitos_apps:
+    release:
+      packages:
+      - scitos_cmd_vel_mux
+      - scitos_dashboard
+      - scitos_docking
+      - scitos_ptu
+      - scitos_teleop
+      - scitos_touch
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/scitos_apps.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_apps.git
       version: hydro-devel
+    status: developed
   scitos_common:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_apps` to `0.0.1-0`:
- upstream repository: https://github.com/strands-project/scitos_apps.git
- release repository: https://github.com/strands-project-releases/scitos_apps.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## scitos_cmd_vel_mux

```
* [scitos_cmd_vel_mux] Set version number to 0.0.0 to have a common start.
* Added license to package.xml
* Release preparations
* adding machine tags to cmd_vel_mux, teleop_joystick and scitos docking launch files
* Renamed topics of comd_vel_mux to match the old ones
  Also changed the name to yocs_cmd_vel_mux in package.xml to allow automated installation.
* Changed the name of the cmd_vel_mux in launch file to new version
* updated dependency: package got renamed under hydro
* Added README file with basic instructions.
  Updated package.xml to make rosdep work.
* Added implementation of cmd_vel_mux to allow arbitration. To use run scitos_teleop_mux.launch and have the navigation publish to /cmd_vel_mux/input/navigation instead of /cmd_vel.
  Joystick will now get priority over navigation if dead-man-switch is pressed.
* Contributors: Christian Dondrup, Jaime Pulido Fentanes, Lars Kunze, cdondrup
```
## scitos_dashboard

```
* [scitos_dashboard] Added description and author to package xml
* [scitos_dashboard] Added install targets and setup.py
* [scitos_dashboard] diagnostics_msgs not used.
* Update README.md
* adding documentation
* screenshot for documentation
* prep to move dashboard to apps
* Contributors: Chris Burbridge, Christian Dondrup, cburbridge, cdondrup
```
## scitos_docking

```
* [scitos_ptu] release preparations.
* [scitos_docking] Realease preparation
  * Moved header files to include
  * Created proper directories
  * Created install targets
  * Cleaned package.xml
  * Added license
* added opencv2
* added libncurses-dev as dependency
* [scitos_door_pass] Removed double dependencies and added move_base_msgs to package.xml
* Charging action and service is now part of the scitos_docking package.
* Moved action_buttons message to scitos_teleop package.
* Renamed ros_datacentre to mongodb_store
  This simply bulk replaces all ros_datacentre strings to mongodb_store strings inside files and also in file names.
  Needs strands-project/ros_datacentre#76 <https://github.com/strands-project/ros_datacentre/issues/76> to me merged first.
* adding machine tags to cmd_vel_mux, teleop_joystick and scitos docking launch files
* Merge pull request #82 <https://github.com/strands-project/scitos_apps/issues/82> from gestom/hydro-devel
  Charging now split into three action servers: docking, undocking and cha...
* Charging now split into three action servers: docking, undocking and chargingServer. ChargingServer can dock, undock, and calibrate depending on the command it receives. Docking and undocking servers receive MoveBase goal, so they can be integrated in Topological navigation.
* Using the ${catkin_EXPORTED_TARGETS} macro in all the add_dependencies statements now.
* Changed bracketing to fix compilation error.
* Switched strands_datacentre to ros_datacentre in here
* Merge pull request #50 <https://github.com/strands-project/scitos_apps/issues/50> from hawesie/master
  Linking changes for OSX
* Merge branch 'master' of https://github.com/hawesie/scitos_apps
* Should fix the dependency problem for the data_centre
* added dependency for datacentre
* OS X linking
* Dependencies of CPtuClient
* Linking changes for OSX
* Docking position injection improvement.
* Minor issue with position injection timestamp.
* Attempt to resolve the undocking simulation failure.
* Merge pull request #31 <https://github.com/strands-project/scitos_apps/issues/31> from hawesie/master
  Seems to work OK.
* Merge branch 'master' of https://github.com/hawesie/scitos_apps into hawesie-master
* Position injection into AMCL after undocking.
* Dependecy bug corrected.
* Publishing after preemption suppressed.
* Charging in the dark
* Added MongoDB support to store calibration params. Corrected reports on success or failure. Command multiplexer made optional.
* Linking commands necessary for OS X.
* A potential bug, which caused the visual charging to fail in simulation, has been removed. Moreover, the undocking now starts with slowly opening the eyes. That gives the users some time to leave the area behind the robot.
* A potential bug, which caused the visual charging to fail in simulation, has been removed. Moreover, the undocking now starts with slowly opening the eyes. That gives the users some time to leave the area behind the robot.
* Added missing instruction.
* Updated documentation to cover actionlib.
* Added dependencies to CMakeLists, extended the testing mode of visual charging
* Test script modification.
* Test script modified.
* Calibration params now saved to /.charging.yaml. Code rewritted towards human redability. Docking/undocking can be initiated by joystick button X. Controller speed-up. Added test mode for automated trials and a test script.
* Docs update
* Documentation update.
  Removed redundant files.
* Added a client for testing, modified messages to report on progress and implemented simple self-diagnostic.
* Charging process now an actionlib server.
* Calibration parameters now saved in etc/charging.yaml, so calibration has to be performed only once.
* Minor changes to robot controllers.
* Solving compatibility issues with simulator.
* Explicit stop when waiting for charger signal.
* Rotation of the robot stopped after undocking and charging.
* Charging rejected on missing calibration parameters.
* No charging attempted without proper calibration params.
* Bug in retreival of camera parameters resolved.
* Stop command send explicitly after the docking or undocking terminates.
  Camera parameters can be changed on the fly.
* Small improvements to docking code.
* CMalelist improved to conform with source name change.
* Image processing now running on monochromatic image.
* Towards compatibility with the MORSE simulator:
  1) Listening to Battery state rather than Charging status.
  2) Image processing modified to include alpha channel processing.x
* Documentation added.
* Undocking + improvements to increase docking success rate.
* Added a robot station label.
  Updated a readme file.
* rosdep fixed for gsl
* Added gsl find and linking for compile on osx.
* fixed a renaming bug.
* Some urgent restructuring and adding of dependencies to make it build again.
* command now precedes timeout
* Solving compilation issues with scitos_messages.
* Cleanup.
* First verstion of the docking.
* Contributors: BFALacerda, Bruno Lacerda, Christian Dondrup, Computing, Jaime Pulido Fentanes, Marc Hanheide, Nick Hawes, Tom Krajnik, Tomas Krajnik, cdondrup, strands
```
## scitos_ptu

```
* [scitos_ptu] release preparations.
* Merge branch 'hydro-devel' into dependencies
  Conflicts:
  scitos_door_pass/CMakeLists.txt
  scitos_door_pass/package.xml
  scitos_teleop/CMakeLists.txt
  scitos_teleop/package.xml
* Fixing the maintainer and author entries in package xml files that I am involved in.
* [scitos_ptu] adding actionlib to CMakeLists
* [scitos_ptu] Prerelease cleanup
  Removed unused toy node.
* Increased the time out time from 3 to 10 seconds
* adding respawning launch for metric maps ptu action server
* Bugfix in ptu_action_server_metric_map. Resetting the aborted flag
* accepting preemption during initial pose
* metric map action server now preempts flir action server instead of waiting for it to finish
* Bugfix flir_ptu_action_server
* Preempting the underlying action server
* Added preemption method to flir_ptu_action_server
* Metric map sweep publishes log string when preempted
* fixed typos
* Metric map now preemptable
* new node name
* default joint names for when in simulation
* correcting action message import
* ptu launch file
* adding flir_ptu_d46 action server messages
* moving scripts up
* Renamed the action server
* renamed the action server
* Added a log topic for the ptu server
* new ptu server that logs to the database
* action server feedback message
* Added feedback in the ptu action server
* Action message with fields for various parameters
* Moving the action file to the root of the package
* updated the PTU action server to check that the desired position has been reacheed using the /ptu/state message
* package dependencies
* action server for ptu
* Restructuring and renaming.
* Contributors: Chris Burbridge, Christian Dondrup, Rares Ambrus, annotator, cburbridge, cdondrup, default, rares
```
## scitos_teleop

```
* Merging somehow removed the std_msgs.
* Merge branch 'hydro-devel' into dependencies
  Conflicts:
  scitos_door_pass/CMakeLists.txt
  scitos_door_pass/package.xml
  scitos_teleop/CMakeLists.txt
  scitos_teleop/package.xml
* Some more merging.
* Merge branch 'hydro-devel' into teleop
  Conflicts:
  scitos_teleop/CMakeLists.txt
  scitos_teleop/package.xml
* Fixing the maintainer and author entries in package xml files that I am involved in.
* remove from package.xml as well.
* [scitos_teleop] CMakeLists was missing dependecies specified in package.xml. std_msgs not used.
* Installing the udev rule directly won't work properly. Following the example of http://wiki.ros.org/kobuki_ftdi now, using a script to do it.
  This can be run with rosrun scitos_teleop create_udev_rules
* Added license file
* Prerelease cleanup
  * the udev rule has been renamed to identify it's origin.
  * the udev rule will be automatically installed and therefore /dev/input/rumblepad is now the default.
* Moved action_buttons message to scitos_teleop package.
* Enabling the scitos services again.
  In the beginning of the project the scitos_msgs where hidden in the scitos drivers repository which made it necessary to check for the existence of the package during compile time because the joystick should also work in simulation where there is not scitos_drivers repository.
  Once the scitos_msgs where moved to scitos_common, I removed this check from the CMakeLists but forgot to remove the compiler flag from the code. Therefore the rumble_control was always compiled without these service enabled.
  This is fixed now.
* fixing machine tags for scitos_teleop
* adding machine tags to cmd_vel_mux, teleop_joystick and scitos docking launch files
* Using the ${catkin_EXPORTED_TARGETS} macro in all the add_dependencies statements now.
* added scitos_apps_msgs as dependency
* add joy as dependency
* Docking position injection improvement.
* Joystick now allows to control forward acceleration by cross buttons (axis 7) and speed by stick (axis 1)
* Actually passing along the js argument from every top-level launch file to the core launch file.
  Closing issue #26 <https://github.com/strands-project/scitos_apps/issues/26>
* Update README.md
  Removed very old and confusing set-up instructions and replaced with link to strands_systems readme file. Also added a link to cmd_vel_mux so that people know about it.
* Update README.md
  Update troubleshooting because of: https://github.com/strands-project/autonomous_patrolling/issues/33
* Using new EyeLids JointState to move eye lids in sync.
* Some urgent restructuring and adding of dependencies to make it build again.
* Update teleop_joystick_mux.launch
  Remove call to cmd_vel_mux to keep it more general usable.
* Added implementation of cmd_vel_mux to allow arbitration. To use run scitos_teleop_mux.launch and have the navigation publish to /cmd_vel_mux/input/navigation instead of /cmd_vel.
  Joystick will now get priority over navigation if dead-man-switch is pressed.
* adapting to the changes by cburbridge
* fix scitos_msgs depend
* Fixed a bug with the message generation.
* Updated Readme file
* Updated cheat sheet.
* Bugfix. Forgot a self.
* Bugfi for the zero position button. Now works if inversed as well.
* Now the rumbepad control just sends button messages when they change.
  The head can be turned backwards if you hit Y.
* Updated and created new launch files to start just the core functionalities, just head, just base and all.
* The head and eye control are now in the safe python script and not seperated anylonger.
* Seperated the rumblepad_control and teleop_base.
  rumbelpad_control now takes responsibility of republishing the joy msg if the pad is in the right mode and the deadman switch is pressed. It also provides the emergency stop and motor reset functionalities.
  teleop_base just transformes the joystick mesages from teleop_joystick/joy published by the rumblepad_control to veleocities for /cmd_vel
* fixing messed up file
* Using parameter for joystick device
* Using parameter for joystick device
* Setting joysick to system independent name
* Now the robot also moves the eyes when moving the head with the joystick and when pressing the top right shoulder button it sets the head position to 0 0.
* Moved the aaction button message to scitos_apps_msgs.
* rumblepad_control is now checking if the pad runs in teh correct mode to prevent confusion because of a wrong button layout.
* Now publishing a custom button message containing 4 bools, one for every action button.
* Created a message for the action buttons
* Changed namespace to teleop_joystick
* Update README.md
  Some troubleshooting info added.
* Added a readme to explain baisc installation and usage of the scitos_teleop package.
* Adapted file structure to match pr2_teleop.
  Changed CMakeLists.txt and package.xml to reflect the new name scitos_teleop.
  Renamed rumblepad_control.launch to teleop_joystick.launch and changed the names according to new package name.
* Moved rumblepad_control to scitos_teleop/src
* Contributors: Bruno Lacerda, Chris Burbridge, Christian Dondrup, Jaime Pulido Fentanes, Marc Hanheide, Tom Krajnik, cburbridge, cdondrup
```
## scitos_touch

```
* [scitos_touch] resetting version number.
* Merge branch 'hydro-devel' into dependencies
  Conflicts:
  scitos_door_pass/CMakeLists.txt
  scitos_door_pass/package.xml
  scitos_teleop/CMakeLists.txt
  scitos_teleop/package.xml
* Fixing the maintainer and author entries in package xml files that I am involved in.
* [scitos_touch] Added std_msgs to CMakeLists
* Added license file
* [scitos_touch] Prerelease cleanup
* Using the ${catkin_EXPORTED_TARGETS} macro in all the add_dependencies statements now.
* ifdef to remove boost join parse error.
* Bug fix:
  Do not use own nodehandle but use getNodeHandle to let rqt take care of your subscribers.
* changed initial motor state assumption to motors are running.
* start with assumption that motors are off in the beginning.
* Added some comments and deleted rubbish from package.xml
* Bug fixing:
  forgot to start the ros:spin thread and had to add a ! for the colour change
  The button is now a bit smaller to be able to use something else besides the button in rqt.
  The colour is now only changed if there is real change in the value.
* Complete restructuring.
  Getting rid of ros_comm because it is not needed and complicates erverything.
* Missing connect function added to give some functionality to the button.
* Remodeling the emergency stop button into an rqt plugin.
  First attempt. Limited functionality.
* Added documentation.
* added scitos_msgs_genccp dependency.
* Fixed dependencies and removed "glob"-ing from CMakeLists to make it clean.
* Button toggle is now based on service success.
* Listening to the /bumper topic to determine the real state of the motors instead of guessing from service success.
* Making Qt stop gracefully when catching sigint or sigterm.
  Calling ros::shutdown when Qt app quits.
* Button now changes colour when pressed and motors are successfully stopped.
* bug fix.
* Toggle between emergency stop and reset motors.
* First working version. Should stop motors on button press. Still not clean. Segfaults when closed because ros::spin is not properly terminated yet.
* Base framework for a touchscreen emergency stop button. No funtionality yet.
* Contributors: Christian Dondrup, Nick Hawes, cdondrup
```
