### PR TITLE
strands_apps: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7523,6 +7523,22 @@ repositories:
       type: git
       url: https://github.com/srv/stereo_slam.git
       version: hydro
+  strands_apps:
+    release:
+      packages:
+      - door_pass
+      - ramp_climb
+      - reconfigure_inflation
+      - state_checker
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_apps.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/strands-project/strands_apps.git
+      version: hydro-devel
+    status: developed
   strands_executive:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.0.1-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.11`
- previous version for package: `null`
## door_pass

```
* Added license files
* [door_pass] preparing cmake and package file for release
* Removed scitos prefix for door_pass and ramp_climb
* Contributors: Christian Dondrup
```
## ramp_climb

```
* Added license files
* [ramp_climb] preparing cmake and package files for release
* Removed scitos prefix for door_pass and ramp_climb
* Contributors: Christian Dondrup
```
## reconfigure_inflation

```
* Added license files
* Wrong URL
* [reconfigure_inflation] Preparing cmake and package file for release
* renamed package to get rid of the scitos prefix.
  None of the other packages seems to use this so no refactoring needed.
* Contributors: Christian Dondrup
```
## state_checker

```
* Added license files
* [state_checker] prepared cmake and package file for release
  Added setup.py for installtion
* Recreated state_checker directory
* Contributors: Christian Dondrup
```
