### PR TITLE
mongodb_store: 0.0.5-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2571,7 +2571,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.0.4-0
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.0.5-1`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.4-0`
## mongodb_log
- No changes
## mongodb_store

```
* Added install target for launch file.
* Fix maintainer in package.xml
* Update package.xml
* Contributors: Chris Burbridge, Marc Hanheide, Nick Hawes
```
## mongodb_store_cpp_client

```
* Fixed typo.
* Added absolute paths to libraries to ensure that dependent projects get correct linking.
* Contributors: Nick Hawes
```
## mongodb_store_msgs
- No changes
