### PR TITLE
scitos_apps: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7187,7 +7187,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_apps.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_apps` to `0.0.4-0`:
- upstream repository: https://github.com/strands-project/scitos_apps.git
- release repository: https://github.com/strands-project-releases/scitos_apps.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-0`
## scitos_cmd_vel_mux
- No changes
## scitos_dashboard
- No changes
## scitos_docking

```
* Merge branch 'hydro-devel' of https://github.com/strands-project/scitos_apps into hydro-devel
* Removed debug messages
* Undocking preemption bug solved.
* Contributors: Tom Krajnik
```
## scitos_ptu
- No changes
## scitos_teleop
- No changes
## scitos_touch
- No changes
