### PR TITLE
scitos_drivers: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7210,10 +7210,20 @@ repositories:
       version: hydro-devel
     status: developed
   scitos_drivers:
+    release:
+      packages:
+      - flir_pantilt_d46
+      - scitos_drivers
+      - scitos_mira
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/scitos_drivers.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_drivers.git
       version: hydro-devel
+    status: developed
   scriptable_monitoring:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_drivers` to `0.0.2-0`:
- upstream repository: https://github.com/strands-project/scitos_drivers.git
- release repository: https://github.com/strands-project-releases/scitos_drivers.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## flir_pantilt_d46

```
* Added preemption to ptu_action_server
* Adding machine tags to mira, sick and ptu launch files
* removed stupid log
* compelted bug fix after some git troubles
* pulled in
* fixed bug
* Revert "Merge pull request #54 <https://github.com/strands-project/scitos_drivers/issues/54> from marc-hanheide/hydro-devel"
  This reverts commit 71e00ddcabb0ee9981d59033a2cb7b505db08ab9, reversing
  changes made to 51742257dd76556f461efb567828a7d5108bec48. The changes result in
  the /ptu/state topic being broken. Probably because of line 325 in
  flir_pantilt_d46/src/ptu46_driver.cc.
* tested disabling of limits and added to launch file as default
* first shot on no limits
* PTU action server using parameterised joint names
* making PTU unit joint names parameterised
* updating ptu action server to use joint names
* make use of joint name to control joints independently. solves #40 <https://github.com/strands-project/scitos_drivers/issues/40>
* Fixing action server startup
* rename launch
* move launch file to own dir
* prepare to move into scitos_drivers (scitos_mira)
* Contributors: Bob, Chris Burbridge, Jaime Pulido Fentanes, Marc Hanheide, Rares Ambrus, strands
```
## scitos_drivers

```
* metapackage dependends on all subpackages
* rename metapackage to scitos_drivers
* Contributors: Chris Burbridge
```
## scitos_mira

```
* added mira-scitos as dependency
* added default MIRA_PATH to use with debian package
* new SCITOS version
* Adding machine tags to mira, sick and ptu launch files
* made the SCITOSDriver config file an argument to use udev rules at UOL. Shouldn't effect anyone else
* Spinning in own thread seperate to publishing thread.
* Adding exception catching for mira parameter access. Issue #23 <https://github.com/strands-project/scitos_drivers/issues/23>
* Adding exception catching for mira parameter access. Issue #23 <https://github.com/strands-project/scitos_drivers/issues/23>
* Closing issue #41 <https://github.com/strands-project/scitos_drivers/issues/41>. Changed the odometry interval to 20ms. This means that the odometry is sent every 20ms. This is the fastest rate I could achieve. Any faster and the odometry was not published any more. The resulting rate is ~47hz. We tested this odometry rate for quite some time and it does not seem to have any negative effects.
* Update README.md
* Adding conversion of MIRA debug output to ROS debug messages.
* Adding msgs dependency
* Adding bumper to motorstatus topic
* adding abilty to control eyelids in sync
* Update CMakeLists.txt
  including scitos_msgs generation before scitos_mira
* Adding motor status information publication
* Fixing boost::bind usage for MIRA callbacks
* Head lights controllable
* adding headlight callback
* Chaning head state publication frequency to 5hz to save CPU
* Tidy up
* Making SCITOS modules selectable from launch file.
* add launch file
* rename..
* rename scitos_driver=>scitos_mira
* rename scitos_driver to scitos_mira
* rename metapackage to scitos_drivers
* Made into catkin metapackage
* Contributors: Chris Burbridge, Christian Dondrup, Jaime Pulido Fentanes, Marc Hanheide, cburbridge
```
