### PR TITLE
mongodb_store: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2659,12 +2659,11 @@ repositories:
       packages:
       - mongodb_log
       - mongodb_store
-      - mongodb_store_cpp_client
       - mongodb_store_msgs
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.0.5-1
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.0-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.5-1`
## mongodb_log

```
* This adds latched recording and playback to the log and playback nodes.
  This is the final part of the functionality to close #5 <https://github.com/strands-project/mongodb_store/issues/5>
* Added meta logging to other C++ loggers.
* Calling on correct document.
* Building up type processing knowledge.
* Adding meta information to C++-logged documents.
* Handlings strings which cannot be treated as UTF-8 as binary.
* Moved back to processes to test.
* Debugging ulimit issue.
* Contributors: Nick Hawes
```
## mongodb_store

```
* Removing author emails as seems to be done on for other packages.
* Added option to specify database.
* Updated URL and description.
* Fixed pacakge name in test launch file.
* Added boost to dependencies.
  Refactoring of package earlier plus this fixes #95 <https://github.com/strands-project/mongodb_store/issues/95> (hopefully)
* Added cpp changelog to overall package.
* Moved mongodb_store_cpp_client files into mongodb_store package.
* This adds latched recording and playback to the log and playback nodes.
  This is the final part of the functionality to close #5 <https://github.com/strands-project/mongodb_store/issues/5>
* Looking in to date issue.
* Adding meta information into C++ logging.
* Building up type processing knowledge.
* Adding meta information to C++-logged documents.
* Handlings strings which cannot be treated as UTF-8 as binary.
* Debugging ulimit issue.
* First full working version.
  Topics are played back but this is all at the mercy of rospy.sleep
* All processes with sim time.
* Sim time is now awaited correctly.
* Added basic processes for topic publishing.
* Playback node now publishes simulated time.
* Contributors: Nick Hawes
```
## mongodb_store_msgs
- No changes
