### PR TITLE
mongodb_store: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3691,7 +3691,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.1-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.0-0`
## mongodb_log
- No changes
## mongodb_store

```
* Merge pull request #99 <https://github.com/strands-project/mongodb_store/issues/99> from hawesie/hydro-devel
  Added geometry_msgs back in to fix #98 <https://github.com/strands-project/mongodb_store/issues/98>
* Added geometry_msgs back in to fix #98 <https://github.com/strands-project/mongodb_store/issues/98>
* Contributors: Nick Hawes
```
## mongodb_store_msgs
- No changes
