### PR TITLE
strands_perception_people: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7769,6 +7769,28 @@ repositories:
       type: git
       url: https://github.com/strands-project/strands_navigation.git
       version: hydro-devel
+  strands_perception_people:
+    release:
+      packages:
+      - bayes_people_tracker
+      - bayes_people_tracker_logging
+      - detector_msg_to_pose_array
+      - ground_plane_estimation
+      - mdl_people_tracker
+      - odometry_to_motion_matrix
+      - perception_people_launch
+      - strands_perception_people
+      - upper_body_detector
+      - visual_odometry
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_perception_people.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/strands-project/strands_perception_people.git
+      version: hydro-devel
+    status: developed
   strands_webtools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `0.0.2-0`:
- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## bayes_people_tracker
- No changes
## bayes_people_tracker_logging
- No changes
## detector_msg_to_pose_array
- No changes
## ground_plane_estimation
- No changes
## mdl_people_tracker
- No changes
## odometry_to_motion_matrix
- No changes
## perception_people_launch

```
* Removed ground_hog from run_deps
* Contributors: Christian Dondrup
```
## strands_perception_people
- No changes
## upper_body_detector
- No changes
## visual_odometry
- No changes
