### PR TITLE
strands_apps: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7736,13 +7736,14 @@ repositories:
     release:
       packages:
       - door_pass
+      - pose_extractor
       - ramp_climb
       - reconfigure_inflation
       - state_checker
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_apps.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/strands-project/strands_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## door_pass
- No changes
## pose_extractor

```
* Adjusted version to match the version number of the other packages.
* Created changelog
* Prepared for release
* Recreated directory
* Contributors: Christian Dondrup
* Prepared for release
* Recreated directory
* Contributors: Christian Dondrup
```
## ramp_climb
- No changes
## reconfigure_inflation
- No changes
## state_checker
- No changes
