### PR TITLE
mongodb_store: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3691,7 +3691,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.2-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.1-0`
## mongodb_log
- No changes
## mongodb_store

```
* removed if statement on MONGO_EXPORT
* Using warehouse_ros approach to including MongoDB.
  Added FindMongoDB for this.
* Looks like linking is necessary
* Removing modern c++ for safety.
* Trying to only expose mongo lib for apple.
* Added geometry_msgs back in
* Contributors: Marc Hanheide, Nick Hawes
```
## mongodb_store_msgs
- No changes
