### PR TITLE
ros_systems: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6263,6 +6263,19 @@ repositories:
       url: https://github.com/ros/ros_realtime.git
       version: hydro-devel
     status: maintained
+  ros_systems:
+    release:
+      packages:
+      - lcas_hri
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/ros_systems.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/LCAS/ros_systems.git
+      version: master
+    status: developed
   ros_tutorials:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_systems` to `0.0.2-0`:
- upstream repository: https://github.com/LCAS/ros_systems.git
- release repository: https://github.com/strands-project-releases/ros_systems.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## lcas_hri

```
* Fixing mongodb dependencies
* Contributors: Christian Dondrup
```
