### PR TITLE
scitos_common: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4997,10 +4997,20 @@ repositories:
       url: https://github.com/strands-project/scitos_apps.git
       version: hydro-devel
   scitos_common:
+    release:
+      packages:
+      - scitos_common
+      - scitos_description
+      - scitos_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/scitos_common.git
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_common.git
       version: hydro-devel
+    status: developed
   sentis_tof_m100:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_common` to `0.1.0-0`:
- upstream repository: https://github.com/strands-project/scitos_common.git
- release repository: https://github.com/strands-project-releases/scitos_common.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## scitos_common
- No changes
## scitos_description

```
* Removed the run_depend on calibrate_chest also
* Removed the chest camera links in the urdf and launch file, added them to strands_description instead
* Removed the calibrate_chest package, already in strands_movebase and added the package as a run_depend in scitos_desciption
* Contributors: Nils Bore
```
## scitos_msgs
- No changes
