### PR TITLE
scitos_apps: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5010,10 +5010,23 @@ repositories:
       version: master
     status: maintained
   scitos_apps:
+    release:
+      packages:
+      - scitos_cmd_vel_mux
+      - scitos_dashboard
+      - scitos_docking
+      - scitos_ptu
+      - scitos_teleop
+      - scitos_touch
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/scitos_apps.git
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_apps.git
       version: hydro-devel
+    status: developed
   scitos_common:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_apps` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/scitos_apps.git
- release repository: https://github.com/strands-project-releases/scitos_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## scitos_cmd_vel_mux
- No changes
## scitos_dashboard
- No changes
## scitos_docking

```
* Replacing opencv2 dependency with cv_bridge to be distribution independent.
  opencv2 does not exists under indogo anymore. cv_bridge is pulling in the correct opencv packages for both distributions.
* Contributors: Christian Dondrup
```
## scitos_ptu
- No changes
## scitos_teleop
- No changes
## scitos_touch
- No changes
