### PR TITLE
strands_apps: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5441,10 +5441,22 @@ repositories:
       version: 0.2.0-0
     status: developed
   strands_apps:
+    release:
+      packages:
+      - door_pass
+      - pose_extractor
+      - ramp_climb
+      - reconfigure_inflation
+      - state_checker
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_apps.git
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/strands-project/strands_apps.git
       version: hydro-devel
+    status: developed
   strands_webtools:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## door_pass
- No changes
## pose_extractor

```
* Adjusted version to match the version number of the other packages.
* Created changelog
* Prepared for release
* Recreated directory
* Contributors: Christian Dondrup
* Prepared for release
* Recreated directory
* Contributors: Christian Dondrup
```
## ramp_climb
- No changes
## reconfigure_inflation
- No changes
## state_checker
- No changes
