### PR TITLE
twitter_bootstrap: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8049,6 +8049,17 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_viz.git
       version: hydro
     status: maintained
+  twitter_bootstrap:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/twitter_bootstrap.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/strands-project/twitter_bootstrap.git
+      version: master
+    status: maintained
   typelib:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `twitter_bootstrap` to `0.0.1-0`:
- upstream repository: https://github.com/strands-project/twitter_bootstrap.git
- release repository: https://github.com/strands-project-releases/twitter_bootstrap.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## twitter_bootstrap

```
* added a bit more in README
* added changelog
* added install target
* added LICENSE
* Merge branch 'master' of https://github.com/strands-project/twitter_bootstrap
* Fixed project name.
* changed package name
* fixed package name
* Updated package.xml.
* Update README.md
* Version number added.
* Cleaned up for sharing
* Added bootstrap
* Removed submodule
* Creating packaging and adding bootstrap submodule
* Initial commit
* Contributors: Marc Hanheide, Nick Hawes
```
