### PR TITLE
twitter_bootstrap: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5571,6 +5571,17 @@ repositories:
       url: https://github.com/turtlebot/turtlebot_arm.git
       version: indigo-devel
     status: developed
+  twitter_bootstrap:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/twitter_bootstrap.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/strands-project/twitter_bootstrap.git
+      version: master
+    status: maintained
   ublox:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `twitter_bootstrap` to `0.0.1-0`:
- upstream repository: https://github.com/strands-project/twitter_bootstrap.git
- release repository: https://github.com/strands-project-releases/twitter_bootstrap.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## twitter_bootstrap

```
* added a bit more in README
* added changelog
* added install target
* added LICENSE
* Merge branch 'master' of https://github.com/strands-project/twitter_bootstrap
* Fixed project name.
* changed package name
* fixed package name
* Updated package.xml.
* Update README.md
* Version number added.
* Cleaned up for sharing
* Added bootstrap
* Removed submodule
* Creating packaging and adding bootstrap submodule
* Initial commit
* Contributors: Marc Hanheide, Nick Hawes
```
