### PR TITLE
strands_movebase: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7779,10 +7779,20 @@ repositories:
       version: hydro-devel
     status: developed
   strands_movebase:
+    release:
+      packages:
+      - calibrate_chest
+      - strands_description
+      - strands_movebase
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_movebase.git
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/strands_movebase.git
       version: master
+    status: developed
   strands_navigation:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_movebase` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/strands_movebase.git
- release repository: https://github.com/strands-project-releases/strands_movebase.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## calibrate_chest

```
* added changelogs
* Listed pcl as a dependency in calibrate_chest package.xml
* Removed everything but calibrate chest, preparing for move into strands_movebase
* Contributors: Marc Hanheide, Nils Bore
```
## strands_description

```
* added install targets
* added changelogs
* Cleared up package.xml
* Split the chest camera links out of scitos_description, added them here instead
* Contributors: Marc Hanheide, Nils Bore
```
## strands_movebase

```
* added changelogs
* Added launching of chest transform state publisher together with 3d movebase
* Added the dependencies in catkin_package
* Placed include files in include/strands_movebase and added install targets
* Modified config.launch to use strands_movebase nodes and configs instead of scitos_2d_navigation
* Renamed the launch files and made 3d obstacle avoidance the default
* Corrected the homepage
* Moved the headers to include folder
* Removed move_base.launch since that will be in scitos_2d_navigation
* Mad strands_movebase a package within the repo, to be able to put e.g. chest_calibration in another package
* Contributors: Marc Hanheide, Nils Bore
```
