### PR TITLE
ros_systems: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6264,7 +6264,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/ros_systems.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/LCAS/ros_systems.git


### PR DESCRIPTION
Increasing version of package(s) in repository `ros_systems` to `0.0.3-0`:
- upstream repository: https://github.com/LCAS/ros_systems.git
- release repository: https://github.com/strands-project-releases/ros_systems.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## lcas_hri

```
* Removing scitos_drivers to not install mira
  Adding strands_movebase since it released now.
* Contributors: Christian Dondrup
```
