### PR TITLE
strands_executive: 0.0.1-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7763,10 +7763,20 @@ repositories:
       version: hydro-devel
     status: developed
   strands_executive:
+    release:
+      packages:
+      - scheduler
+      - scipoptsuite
+      - strands_executive_msgs
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_executive.git
+      version: 0.0.1-1
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git
       version: hydro-release
+    status: developed
   strands_morse:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.1-1`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## scheduler

```
* Adding ncurses rosdep and also correct mongodb component order.
* Tidying up package and cmake files.
* Added absolute paths to libraries to ensure that dependent projects get correct linking.
* This simply bulk replaces all ros_datacentre strings to mongodb_store strings inside files and also in file names.
* Added argument for number of instances of scheduler to use.
* updated for better multi support
* Added first task logic to scheduler.
  Also made replay script work with mulitple parallel schedulers.
* Scheduler supports a task, which has the flag NOW
* Fixed issue when no file is given for saving in scheduler
* Added time meaurement for generating constraints and added generation of random schedules
* Adding timeout to scheduler.
* Added 1 minute timeout to scheduler.
* Replay script moves start of task set to 0 to make metrics more sensible.
* Integrated @mudrole1's scheduler changes into node.
* Added file to replay scheduling problems from datacentre
* Added parameter to prevent problem saving.
* Added parameters to scheduler_node and added options, when no parameter is set
* Versions of scheduling algorithm can be chosen now + logging of results to file
* Fixed minor scheduling issues.
  1) Made service calls thread safe.
  2) Fixed order of calls in cancellation
  3) Removed blocking assumption in demand task in scheduler
  4) Changed bounding of tasks based on current execution time.
* Fixed minor scheduling issues.
  1) Made service calls thread safe.
  2) Fixed order of calls in cancellation
  3) Removed blocking assumption in demand task in scheduler
  4) Changed bounding of tasks based on current execution time.
* Reduced calls to mdp time stuff.
* cacheing results, but seems to not be having much effect
* Added logging of scheduling problems to datacentre.
  Inefficient use of space, but faster for CPU (duplicating db content with tasks).
* Added logging of scheduling problems to datacentre.
  Inefficient use of space, but faster for CPU (duplicating db content with tasks).
* Quick fix for empty node ids waiting for #41 <https://github.com/strands-project/strands_executive/issues/41>
* getting scheduler to call right expected time service
* first version of mdp policy execution
* Clarified behaviour around rescheduling after a demand.
  Dropping of out-of-bounds additional tasks are not handled separately to out-of-bounds previously scheduled tasks.
* reverting change in scheduler
* getting example task routines to have proper start and ending points
* Removed pre-variables, enlarged handling of preceding constraints
* Changes for on demand tasks.
  Added service for on-demand tasks.
  Restructued scheduled executor to separate new and old tasks, with the aim to allow this to be used to recover tasks overridden by on-demand requests.
* Adding prism and initial prism-ros interaction
* Delayed execution tasks now working correctly with timer.
* Publishing schedule and handling scheduler fail.
* Set up for just patrolling. Launch file printing to screen sensible amounts.
* Fixed bug, that time t was preceeding start of a task
* Compilation under linux now.
* Looking to add time delays to scheduler and executor, but bug found in scheduler.
* Setting up scheduler tests.
* Running scheduler, receiving back at execution framework.
* Working calls to the scheduler!
* Scheduler C++ node is now called with tasks.
* Adding infrastructure for scheduled execution.
* Compiled from scratch.
* A working compiler with lots of cmake hacks.
* Contributors: Bruno Lacerda, Lenka Mudrova, Nick Hawes
```
## scipoptsuite

```
* Adding ncurses rosdep and also correct mongodb component order.
* Added absolute paths to libraries to ensure that dependent projects get correct linking.
* Updated dependencies.
* Added libgmp3-dev depenency. Fixes #23 <https://github.com/strands-project/strands_executive/issues/23>.
* libgmp-dev build_depend
* Compilation under linux now.
* Added md5 hash.
* Adapting build to now apply patches on linux.
* Working calls to the scheduler!
* Added platform switches.
  Now to test on linux vm.
* Compile of scheduler from scratch.
* Linking libraries to platform independent names.
* Compiled from scratch.
* A working compiler with lots of cmake hacks.
* Files installed into correct places, but not through standard ways.
  It's not clear why the cmake install commands are not being executed, but it could because the project doesn't have a proper target.
* First commit of scipoptsuite external build
* Contributors: Chris Burbridge, Nick Hawes
```
## strands_executive_msgs

```
* Tidying up package and cmake files.
* This simply bulk replaces all ros_datacentre strings to mongodb_store strings inside files and also in file names.
* Added first task logic to scheduler.
  Also made replay script work with mulitple parallel schedulers.
* Added summary printing script
* Fixed minor scheduling issues.
  1) Made service calls thread safe.
  2) Fixed order of calls in cancellation
  3) Removed blocking assumption in demand task in scheduler
  4) Changed bounding of tasks based on current execution time.
* Logging working from state machine now.
* Fixed minor scheduling issues.
  1) Made service calls thread safe.
  2) Fixed order of calls in cancellation
  3) Removed blocking assumption in demand task in scheduler
  4) Changed bounding of tasks based on current execution time.
* Logging working from state machine now.
* Added bool type to task
* Added logging of task event changes to message store.
* Added logging of task event changes to message store.
* allowing larger timeouts for travel time learning action
* adding srv file for special waypoints addition and removal; small bug fixes
* code cleaning and travelling times learning action added
* first version of mdp policy execution
* adding service to update the mdp using the navigation statistics in the db
* On demand tasks working.
  Also added in time and duration types for tasks.
  After a demand the scheduler tries to schedule back in the previously scheduled but unexecuted tasks. If this is not successful then these tasks are dropped. If these are successfully scheduled back in then it also tries to schedule back in the task which was interrupted by the demand. If this is not possible only the interrupted task is dropped.
  Demands can be interrupted by timeout and by subsequent demanded tasks.
* Changes for on demand tasks.
  Added service for on-demand tasks.
  Restructued scheduled executor to separate new and old tasks, with the aim to allow this to be used to recover tasks overridden by on-demand requests.
* Really adding prism
* Adding prism and initial prism-ros interaction
* Delayed execution tasks now working correctly with timer.
* Publishing schedule and handling scheduler fail.
* Trying to get routine adding tested.
* Moved to adding tasks in a batch. Old interface left for compatibility.
* Running scheduler, receiving back at execution framework.
* Working calls to the scheduler!
* Scheduler C++ node is now called with tasks.
* Adding infrastructure for scheduled execution.
* Added int and float arguments to task execution.
* Basic test of FIFO done and working.
  Works from the command line, but can't seem to make the rostest integration work.
* Basic execution flow through abstract and FIFO working.
* Moved test action to task_executor, adding server to provide it.
* Basic node comms working.
* Working basic task creation.
* Adding action and msg types for interaction with task framework.
* Added messages and structure.
* Contributors: Bruno Lacerda, Nick Hawes
```
