### PR TITLE
strands_movebase: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5555,7 +5555,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_movebase.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/strands-project/strands_movebase.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_movebase` to `0.0.6-0`:
- upstream repository: https://github.com/strands-project/strands_movebase.git
- release repository: https://github.com/strands-project-releases/strands_movebase.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.5-0`
## calibrate_chest
- No changes
## strands_description
- No changes
## strands_movebase

```
* Decreased the cost_scaling_factor, making the robot stay away from walls if possible. This made navigation more robust on Rosie, particularly through doors
* Contributors: Nils Bore
```
