### PR TITLE
strands_social: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7860,10 +7860,21 @@ repositories:
       version: hydro-devel
     status: developed
   strands_social:
+    release:
+      packages:
+      - datamatrix_read
+      - fake_camera_effects
+      - image_branding
+      - strands_tweets
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_social.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/strands-project/strands_social.git
       version: hydro-devel
+    status: developed
   strands_webtools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_social` to `0.0.2-0`:
- upstream repository: https://github.com/strands-project/strands_social.git
- release repository: https://github.com/strands-project-releases/strands_social.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## datamatrix_read
- No changes
## fake_camera_effects
- No changes
## image_branding
- No changes
## strands_tweets

```
* removed space
* Contributors: Jaime Pulido Fentanes
```
