### PR TITLE
strands_executive: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7833,7 +7833,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.1-2
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.1-2`
## scheduler

```
* 0.0.2
* Updated CHANGELOGs.
* Changes to build for both single package and repo.
  Having problems with exposing libs created by scipoptsuite which are not actually targets.
* Moving mongodb-store component to top of list for linking errors.
* Added cmake extras to set include directories correctly for scipoptsuite.
* Contributors: Nick Hawes
```
## scipoptsuite

```
* 0.0.2
* Updated CHANGELOGs.
* Removed readline from scipoptsuite build as we don't have an interactive interface in ROS.
* Installing library files now with link targets as well.
* Empty commit to poke Jenkins.
* Changes to build for both single package and repo.
  Having problems with exposing libs created by scipoptsuite which are not actually targets.
* Now correctly fixing build dir problem.
  I was previously hardcoding the prefix in devel space which could either have been strands_executive/scipoptsuite or just scipoptsuite depending on whether this was built as standalone package or a in repo. This can be reflected in the cmake file with the scipoptsuite_BINARY_DIR variable so now I'm using that.
* Added cmake extras to set include directories correctly for scipoptsuite.
* Adding install targets and fixing build prefix for release.
* Contributors: Nick Hawes
```
## strands_executive_msgs

```
* 0.0.2
* Updated CHANGELOGs.
* Contributors: Nick Hawes
```
