### PR TITLE
strands_executive: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5567,6 +5567,21 @@ repositories:
       url: https://github.com/strands-project/strands_apps.git
       version: hydro-devel
     status: developed
+  strands_executive:
+    release:
+      packages:
+      - scheduler
+      - scipoptsuite
+      - strands_executive_msgs
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_executive.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/strands-project/strands_executive.git
+      version: hydro-devel
+    status: developed
   strands_movebase:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## scheduler

```
* 0.0.2
* Updated CHANGELOGs.
* Changes to build for both single package and repo.
  Having problems with exposing libs created by scipoptsuite which are not actually targets.
* Moving mongodb-store component to top of list for linking errors.
* Added cmake extras to set include directories correctly for scipoptsuite.
* Contributors: Nick Hawes
```
## scipoptsuite

```
* 0.0.2
* Updated CHANGELOGs.
* Removed readline from scipoptsuite build as we don't have an interactive interface in ROS.
* Installing library files now with link targets as well.
* Empty commit to poke Jenkins.
* Changes to build for both single package and repo.
  Having problems with exposing libs created by scipoptsuite which are not actually targets.
* Now correctly fixing build dir problem.
  I was previously hardcoding the prefix in devel space which could either have been strands_executive/scipoptsuite or just scipoptsuite depending on whether this was built as standalone package or a in repo. This can be reflected in the cmake file with the scipoptsuite_BINARY_DIR variable so now I'm using that.
* Added cmake extras to set include directories correctly for scipoptsuite.
* Adding install targets and fixing build prefix for release.
* Contributors: Nick Hawes
```
## strands_executive_msgs

```
* 0.0.2
* Updated CHANGELOGs.
* Contributors: Nick Hawes
```
