### PR TITLE
activity_analysis: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -90,6 +90,19 @@ repositories:
       url: https://github.com/ros/actionlib.git
       version: hydro-devel
     status: maintained
+  activity_analysis:
+    release:
+      packages:
+      - strands_engagement_checker
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/activity_analysis.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/strands-project/activity_analysis.git
+      version: hydro-devel
+    status: developed
   agvs:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `activity_analysis` to `0.0.1-0`:
- upstream repository: https://github.com/strands-project/activity_analysis.git
- release repository: https://github.com/strands-project-releases/activity_analysis.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## strands_engagement_checker

```
* Preparing package for release
* Renamed strands_people_tracker to bayes_people_tracker
* strands_perceptiion_people_msgs does not exist any more
  Also using the new people_tracker now
* Changing queue size of publisher to one to prevent triggering the engaged status repeatedly.
* integrated with face detector
* Removed spammy output
* Working and publishing version of engagement checker.
  Takes advantage of the functionality of a dictionary to remove magic numbers.
* Complete restructuring and renaming of code and directory
  Actually publishing results
  Still needs testing
* Contributors: Christian Dondrup, Rares Ambrus, strands
```
