### PR TITLE
strands_navigation: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7871,10 +7871,24 @@ repositories:
       version: hydro-devel
     status: developed
   strands_navigation:
+    release:
+      packages:
+      - message_store_map_switcher
+      - monitored_navigation
+      - strands_navigation
+      - strands_navigation_msgs
+      - topological_map_manager
+      - topological_navigation
+      - topological_utils
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_navigation.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git
       version: hydro-devel
+    status: developed
   strands_perception_people:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.2-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
