### PR TITLE
bayes_tracking: 1.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -438,7 +438,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/bayes_tracking.git
-      version: 1.0.3-1
+      version: 1.0.4-0
     source:
       type: git
       url: https://github.com/LCAS/bayestracking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bayes_tracking` to `1.0.4-0`:
- upstream repository: https://github.com/LCAS/bayestracking.git
- release repository: https://github.com/strands-project-releases/bayes_tracking.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.3-1`
## bayes_tracking

```
* Merge pull request #8 <https://github.com/LCAS/bayestracking/issues/8> from LCAS/opencv
  Changing dependency from opencv2 to cv_bridge for indigo release.
* Changing dependency from opencv2 to cv_bridge for indigo release.
* Contributors: Christian Dondrup
```
