### PR TITLE
bayes_tracking: 1.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -244,6 +244,17 @@ repositories:
       url: https://github.com/WPI-RAIL/battery_monitor_rmp.git
       version: develop
     status: maintained
+  bayes_tracking:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/bayes_tracking.git
+      version: 1.0.4-0
+    source:
+      type: git
+      url: https://github.com/LCAS/bayestracking.git
+      version: master
+    status: developed
   bfl:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `bayes_tracking` to `1.0.4-0`:
- upstream repository: https://github.com/LCAS/bayestracking.git
- release repository: https://github.com/strands-project-releases/bayes_tracking.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## bayes_tracking

```
* Merge pull request #8 <https://github.com/LCAS/bayestracking/issues/8> from LCAS/opencv
  Changing dependency from opencv2 to cv_bridge for indigo release.
* Changing dependency from opencv2 to cv_bridge for indigo release.
* Contributors: Christian Dondrup
```
