### PR TITLE
strands_navigation: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7896,7 +7896,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## message_store_map_switcher
- No changes
## monitored_navigation

```
* adding installation of monitored nav launch file
* edited launch file for new launch structure of the ui's
* Contributors: Bruno Lacerda
```
## strands_navigation
- No changes
## strands_navigation_msgs

```
* moving human_help_manager service definition to human_help_manager package
* Contributors: Bruno Lacerda
```
## topological_map_manager
- No changes
## topological_navigation

```
* Merge pull request #94 <https://github.com/strands-project/strands_navigation/issues/94> from Jailander/hydro-devel
  fixing mongodb_store deps
* fixing mongodb_store deps
* Contributors: Jaime Pulido Fentanes, Marc Hanheide
```
## topological_utils

```
* Merge pull request #94 <https://github.com/strands-project/strands_navigation/issues/94> from Jailander/hydro-devel
  fixing mongodb_store deps
* fixing mongodb_store deps
* Contributors: Jaime Pulido Fentanes, Marc Hanheide
```
