### PR TITLE
strands_social: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7939,7 +7939,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_social.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/strands-project/strands_social.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_social` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/strands_social.git
- release repository: https://github.com/strands-project-releases/strands_social.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## datamatrix_read

```
* adding install targets
* Contributors: Jaime Pulido Fentanes
```
## fake_camera_effects

```
* Added install targets, proper dependencies and a launch file.
  Addressing #18 <https://github.com/strands-project/strands_social/issues/18>
* Contributors: Christian Dondrup
```
## image_branding

```
* adding install targets
* Contributors: Jaime Pulido Fentanes
```
## strands_tweets

```
* adding missing dependency
* adding install targets
* Contributors: Jaime Pulido Fentanes
```
