### PR TITLE
strands_perception_people: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5608,6 +5608,28 @@ repositories:
       url: https://github.com/strands-project/strands_movebase.git
       version: hydro-devel
     status: developed
+  strands_perception_people:
+    release:
+      packages:
+      - bayes_people_tracker
+      - bayes_people_tracker_logging
+      - detector_msg_to_pose_array
+      - ground_plane_estimation
+      - mdl_people_tracker
+      - odometry_to_motion_matrix
+      - perception_people_launch
+      - strands_perception_people
+      - upper_body_detector
+      - visual_odometry
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_perception_people.git
+      version: 0.0.5-0
+    source:
+      type: git
+      url: https://github.com/strands-project/strands_perception_people.git
+      version: hydro-devel
+    status: developed
   strands_webtools:
     source:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## bayes_people_tracker
- No changes
## bayes_people_tracker_logging
- No changes
## detector_msg_to_pose_array
- No changes
## ground_plane_estimation
- No changes
## mdl_people_tracker
- No changes
## odometry_to_motion_matrix
- No changes
## perception_people_launch

```
* The people_msgs package does not exist in indigo yet
* Contributors: Christian Dondrup
```
## strands_perception_people
- No changes
## upper_body_detector
- No changes
## visual_odometry
- No changes
