### PR TITLE
mongodb_store: 0.1.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3732,7 +3732,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.3-1
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.4-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.3-1`
## mongodb_log
- No changes
## mongodb_store

```
* Removed debugging message.
* Fixed inclusion of OpenSSL libraries.
  Note the OpenSSL_LIBRARIES != OPENSSL_LIBRARIES
* Edited find mongo script.
* support backward code compatibility; add test code
* add example to sort query
* add sort option on query
* Contributors: Furushchev, Nick Hawes
```
## mongodb_store_msgs

```
* add sort option on query
* Contributors: Furushchev
```
