### PR TITLE
mongodb_store: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2721,7 +2721,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.3-1
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.4-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.3-1`
## mongodb_log
- No changes
## mongodb_store

```
* Removed debugging message.
* Fixed inclusion of OpenSSL libraries.
  Note the OpenSSL_LIBRARIES != OPENSSL_LIBRARIES
* Edited find mongo script.
* support backward code compatibility; add test code
* add example to sort query
* add sort option on query
* Contributors: Furushchev, Nick Hawes
```
## mongodb_store_msgs

```
* add sort option on query
* Contributors: Furushchev
```
