### PR TITLE
bayes_tracking: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -249,7 +249,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/bayes_tracking.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/LCAS/bayestracking.git


### PR DESCRIPTION
Increasing version of package(s) in repository `bayes_tracking` to `1.0.5-0`:
- upstream repository: https://github.com/LCAS/bayestracking.git
- release repository: https://github.com/strands-project-releases/bayes_tracking.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.4-0`
## bayes_tracking

```
* Merge pull request #9 <https://github.com/LCAS/bayestracking/issues/9> from LCAS/indigo-fix
  Trusty/Indigo fix
* Trusty/Indigo fix
* Contributors: Christian Dondrup
```
