### PR TITLE
strands_executive: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5587,7 +5587,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.4-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-0`
## scheduler

```
* Removed prints.
* Removed explicit linking of message_store library which was causing library not found error.
* Contributors: Nick Hawes
```
## scipoptsuite

```
* Fixing library type for OS X.
* Making install platform independent.
* Contributors: Nick Hawes
```
## strands_executive_msgs

```
* No change
```
