### PR TITLE
strands_navigation: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7897,7 +7897,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.4-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-0`
## message_store_map_switcher

```
* Lowering acceptable yaml version.
* Robustifying cmake file.
* Standardising python parts based on catkin docs.
* Standardising python parts based on catkin docs.
* Fixed build for Indigo
* Contributors: Nick Hawes
```
## monitored_navigation
- No changes
## strands_navigation
- No changes
## strands_navigation_msgs
- No changes
## topological_map_manager
- No changes
## topological_navigation
- No changes
## topological_utils
- No changes
