### PR TITLE
strands_perception_people: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5629,7 +5629,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/strands-project/strands_perception_people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `0.0.8-0`:
- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.7-0`
## bayes_people_tracker
- No changes
## bayes_people_tracker_logging
- No changes
## detector_msg_to_pose_array
- No changes
## ground_plane_estimation
- No changes
## mdl_people_tracker
- No changes
## odometry_to_motion_matrix

```
* eigen still has to be in the package.xml as a build_dependency even though the migration instructions don't suggest that.
* Contributors: Christian Dondrup
```
## perception_people_launch
- No changes
## strands_perception_people
- No changes
## upper_body_detector
- No changes
## visual_odometry

```
* eigen still has to be in the package.xml as a build_dependency even though the migration instructions don't suggest that.
* Contributors: Christian Dondrup
```
