### PR TITLE
strands_navigation: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5609,10 +5609,24 @@ repositories:
       version: hydro-devel
     status: developed
   strands_navigation:
+    release:
+      packages:
+      - message_store_map_switcher
+      - monitored_navigation
+      - strands_navigation
+      - strands_navigation_msgs
+      - topological_map_manager
+      - topological_navigation
+      - topological_utils
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_navigation.git
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git
       version: hydro-devel
+    status: developed
   strands_perception_people:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.4-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## message_store_map_switcher

```
* Lowering acceptable yaml version.
* Robustifying cmake file.
* Standardising python parts based on catkin docs.
* Standardising python parts based on catkin docs.
* Fixed build for Indigo
* Contributors: Nick Hawes
```
## monitored_navigation
- No changes
## strands_navigation
- No changes
## strands_navigation_msgs
- No changes
## topological_map_manager
- No changes
## topological_navigation
- No changes
## topological_utils
- No changes
