### PR TITLE
strands_apps: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7834,10 +7834,11 @@ repositories:
       - ramp_climb
       - reconfigure_inflation
       - state_checker
+      - topic_republisher
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_apps.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/strands-project/strands_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.0.4-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-0`
## door_pass
- No changes
## pose_extractor
- No changes
## ramp_climb
- No changes
## reconfigure_inflation
- No changes
## state_checker
- No changes
## topic_republisher

```
* Adjusted version number to match the others
* Created changelog
* Creating install targets and fixing dependencies.
* Recreated directory
* Contributors: Christian Dondrup
* Creating install targets and fixing dependencies.
* Recreated directory
* Contributors: Christian Dondrup
```
