### PR TITLE
strands_morse: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7864,7 +7864,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.0.3-1
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-1`
## strands_morse

```
* There is no definition for the morse-blender-bundle for fedora yet.
  Bloom complains:
  Could not resolve rosdep key 'morse-blender-bundle' for distro 'heisenbug':
  No definition of [morse-blender-bundle] for OS [fedora]
  rosdep key : morse-blender-bundle
  OS name    : fedora
  OS version : heisenbug
  Data: ubuntu:
  precise:
  - morse-blender-2.65-py-3.3
  removing run_dependency for now.
* Contributors: Christian Dondrup
```
