### PR TITLE
strands_social: 0.0.4-2 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7941,7 +7941,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_social.git
-      version: 0.0.3-0
+      version: 0.0.4-2
     source:
       type: git
       url: https://github.com/strands-project/strands_social.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_social` to `0.0.4-2`:
- upstream repository: https://github.com/strands-project/strands_social.git
- release repository: https://github.com/strands-project-releases/strands_social.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-0`
## datamatrix_read
- No changes
## fake_camera_effects
- No changes
## image_branding
- No changes
## strands_tweets

```
* Merge pull request #23 <https://github.com/strands-project/strands_social/issues/23> from Jailander/hydro-devel
  Removed submodule twython
* fixing setup.py
* adding strands-twython as a dependency
* Removed submodule twython
* Contributors: Jaime Pulido Fentanes
```
