### PR TITLE
strands_perception_people: 0.0.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5660,7 +5660,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 0.0.11-0
+      version: 0.0.13-0
     source:
       type: git
       url: https://github.com/strands-project/strands_perception_people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `0.0.13-0`:
- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.11-0`
## bayes_people_tracker
- No changes
## bayes_people_tracker_logging
- No changes
## detector_msg_to_pose_array
- No changes
## ground_plane_estimation

```
* Making camera topic reconfigurable
  So far only the camera namespace was configurable but that introduced an implicit dependency on the openni_wrapper.
  With these changes the whole topic is reconfigurable via a parameter, e.g.:
  camera_namespace:=/my_cam
  depth_image:=/depth/image
  results in /my_cam/depth/image as a topic for the depth image. So camera_namespace + depth_image = the topic on which to look for the depth image.
* Contributors: Christian Dondrup
```
## mdl_people_tracker

```
* Making camera topic reconfigurable
  So far only the camera namespace was configurable but that introduced an implicit dependency on the openni_wrapper.
  With these changes the whole topic is reconfigurable via a parameter, e.g.:
  camera_namespace:=/my_cam
  depth_image:=/depth/image
  results in /my_cam/depth/image as a topic for the depth image. So camera_namespace + depth_image = the topic on which to look for the depth image.
* Contributors: Christian Dondrup
```
## odometry_to_motion_matrix
- No changes
## perception_people_launch

```
* Making camera topic reconfigurable
  So far only the camera namespace was configurable but that introduced an implicit dependency on the openni_wrapper.
  With these changes the whole topic is reconfigurable via a parameter, e.g.:
  camera_namespace:=/my_cam
  depth_image:=/depth/image
  results in /my_cam/depth/image as a topic for the depth image. So camera_namespace + depth_image = the topic on which to look for the depth image.
* Contributors: Christian Dondrup
```
## strands_perception_people
- No changes
## upper_body_detector

```
* Making camera topic reconfigurable
  So far only the camera namespace was configurable but that introduced an implicit dependency on the openni_wrapper.
  With these changes the whole topic is reconfigurable via a parameter, e.g.:
  camera_namespace:=/my_cam
  depth_image:=/depth/image
  results in /my_cam/depth/image as a topic for the depth image. So camera_namespace + depth_image = the topic on which to look for the depth image.
* Contributors: Christian Dondrup
```
## visual_odometry

```
* Making camera topic reconfigurable
  So far only the camera namespace was configurable but that introduced an implicit dependency on the openni_wrapper.
  With these changes the whole topic is reconfigurable via a parameter, e.g.:
  camera_namespace:=/my_cam
  depth_image:=/depth/image
  results in /my_cam/depth/image as a topic for the depth image. So camera_namespace + depth_image = the topic on which to look for the depth image.
* Contributors: Christian Dondrup
```
