### PR TITLE
strands_ui: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7950,10 +7950,20 @@ repositories:
       version: hydro-devel
     status: developed
   strands_ui:
+    release:
+      packages:
+      - mary_tts
+      - strands_ui
+      - strands_webserver
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_ui.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/strands-project/strands_ui.git
       version: hydro-devel
+    status: developed
   strands_webtools:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_ui` to `0.0.2-0`:
- upstream repository: https://github.com/strands-project/strands_ui.git
- release repository: https://github.com/strands-project-releases/strands_ui.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## mary_tts

```
* Updating dependencies.
  Preparing for release.
* moving human_help_manager service definition to human_help_manager pa…
  …ckage
* 

    * made the Mary start script ROS compatible and installable
    * disabled file logging, closing https://github.com/strands-project/strands_hri/issues/6

* 

    * made speak_webserver installable
    * made template and static dirs to be found
    * tidied up

* changed all ros_mary_tts to mary_tts
* changed package name
* Add 'mary_tts/' from commit 'ee851b0aa5851bc39fe6f13a6c3522d9f4783b74'
  git-subtree-dir: mary_tts
  git-subtree-mainline: 252851fb65fc7aa6c5439377d75a6899794efb36
  git-subtree-split: ee851b0aa5851bc39fe6f13a6c3522d9f4783b74
* Contributors: Bruno Lacerda, Christian Dondrup, Marc Hanheide
```
## strands_ui

```
* Removed nav_help_s* packages from metapackage run_dependencies. They are now in the recovery behaviour package.
* Creating a "metapackage" containing a strands_ui.launch file
  * The strands_ui package is not a metapackage in the pure sense of the word but has the same functionality + installs a launch file for mary and the webserver. Since metapackages are not allowed to install things it's a regualar package.
  * The strands_ui.launch file launches mary and the webserver together
  * The strands_ui package does not include the marathon gui because I didn't know if that will be released in the first place.
  * The nav_help_* launch files now have a parameter that allows to start the webserver and mary together with the help nodes. This has just been added for backwards compatibility but the default value for the parameters is false to it to peoples attention that the structure has changed.
* Contributors: Christian Dondrup
```
## strands_webserver

```
* changed twitter_bootstrap package name
* added support for page reload
* Removed stray character.
* Added support for multiple webservers.
  The webserver now uses its name to define the service prefix. This means you can run multiple webservers in parallel to show different things, or hosted on different machines, but within the same ros system.
  Default behaviour remains unchanged, i.e. launched with:
```

  rosrun strands_webserver strands_webserver

```
  To run an extra server in parallel on port 8091 with service prefix /bob
```

  rosrun strands_webserver strands_webserver __name:=bob _port:=8091

```
* Added an action server that provides additional functionalities to display webpages like reload, going back and showing temporary pages.
* Added ability to kill webserver on exit.
* Made buttons bigger.
* Allowing local queries for javascript now.
* Passing on requests if not in strands_webserver
* Removing unnecessary README
* Removed broken include
* Added host_ip to launch file
* Added call to make client utils use retrieved server address. Fixes issue #5 <https://github.com/strands-project/strands_ui/issues/5>.
* Added service call to get hostname of webserver
* Updating packages, adding rosinstall info.
* First draft readme finished. Examples updaed for clarity.
* Adding docs
* Adding example and some docs.
* Added example with services being called.
* Service calls now made with auto-generated buttons.
  It's ugly, but it works.
* Added templating for auto-generation of button-based pages with linked services.
  Current problem is that javascript lazily loaded into webserver main page is not evaluated. WIll try to fix this next with an extended message type.
* More proper package structure
* Adding more proper code structure.
* Working setup needs documentation and a proper use case.
* Added option to publish to all registered displays simulataneously by sending a 0 for display number.
* Working test script for rendering a page
* adding an almost working structure
* Contributors: Christian Dondrup, Marc Hanheide, Nick Hawes
```
