### PR TITLE
strands_hri: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7861,6 +7861,24 @@ repositories:
       url: https://github.com/strands-project/strands_executive.git
       version: hydro-release
     status: developed
+  strands_hri:
+    release:
+      packages:
+      - strands_gazing
+      - strands_hri_launch
+      - strands_human_aware_navigation
+      - strands_interaction_behaviours
+      - strands_simple_follow_me
+      - strands_visualise_speech
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_hri.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/strands-project/strands_hri.git
+      version: hydro-devel
+    status: developed
   strands_morse:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_hri` to `0.0.1-0`:
- upstream repository: https://github.com/strands-project/strands_hri.git
- release repository: https://github.com/strands-project-releases/strands_hri.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## strands_gazing

```
* Moved utility scripts out of utils into corresponding packages.
* Added missing webpage
* Prepared strands_gazing for release
* moved the sleep() such that it always gets called in the while loop, irrespective of if-statements
* move some outputs to debug level.
* [strands_gazing]Removed unnecessary subscription to a placeholder topic.
* Removed the pose reset in the gaze_at_pose node to not have it spin around if looking to the back.
* Bugfix: Needs absolute x value to calculate Tilt using atan2 instead of negative one.
* Removing look up tf warning by looking for the right transformation.
* trying to prevent some warning while transforming.
* Using EyeLids joint state to prevent occasional "blinking".
* Changed blink timing to blink every 5 to 20 seconds.
* Bugfix: Added missing *_generate_messages_cpp for the action servers.
* Using ${catkin_EXPORTED_TARGETS} in all packages for tyhe dependecies.
* Now able to look at any given Stamped pose continuously, e.g. /move_base/current_goal
* gaze_at_pose subscribes and unsubscribes automatically depending on whether there is in an active goal or not.
* Random eyeblinking added
* Update README.md
  Fixing typos
* Updated readme with action server info.
* Added a README, updated the package.xml, and changed the standard subscription topic to a more generic one.
* Merge branch 'not_master' of https://github.com/cdondrup/strands_hri
* Added comments and changed info outputs to debug.
* The eye movement does not work as inteded and has been removed for the time being.
* Combining gazing and velocity in one branch.
  Adding dependencies to velocity package.
* First implementation of a node which focuses a 3d pose with the head. Needs testing and some more functionality.
* Contributors: Christian Dondrup, ToMadoRe, Tom Krajnik, cdondrup
```
## strands_hri_launch

```
* Fixing install process and launch file
  Preparing for release once strands_ui is released.
* Prepared strands_hri_launch package for release.
  Needs paose_extractor package to be moved out of strands_utils
* Moved visual_speech script into strands_visualise_speech package
* Renaming dependencies: ros_mary_tts is now mary_tts
* Added launch file for human aware navigation set-up
* Update README.md
  Added comment to have a look at strands_hri_utils.
* Stub readme's
* generic launch package for the strands_hri repo containing the launch file for the speech set-up.
* Contributors: Christian Dondrup
```
## strands_human_aware_navigation

```
* Removed calls to strands_head_orientation as those won't work in a release version.
* Added missing webpage
* Prepared strands_human_aware_navigation for release.
* Renamed strands_people_tracker to bayes_people_tracker
* strands_perception_people_msgs has been removed
* Adapting to new people_tracker message.
* Merge branch 'hydro-devel' into people_tracker
  Conflicts:
  strands_human_aware_navigation/src/scripts/human_aware_navigation.py
* Adapting the human_aware_velocity to the new topic name and type of the people tracker
* running head orientation while human_aware_navigation is running. Only if present. Changed default timeout of engaged server.
* Changing default parameters back to be more social.
* Changed default params
* Setting initial gaze goal for the nav_goal
  resetting the mode in the behaviour switch to prevent it from looking away.
* If human detected, look at human
  else look at nav goal
* Not changing rotational velocity.
* Hard coding "fast" values.
* changes to human aware navigation to handle new goals wothout outputting failure
* Cancelling the gaze goal if move_base is successful.
* Catching service exception for reconfigure.
  Using gaze_at_pose to lock at nav goal.
* Bug fix: subscribing before creating the action server leaad to errors due to checking for a non existing action server in the callback.
* Merge pull request #39 from cdondrup/hydro-devel
  Bug fix. Using dictionary of read parameters now. Needed changing in the...
* Bug fix. Using dictionary of read parameters now. Needed changing in the callback.:w
* Creating action server after every client has been created
* Minor bug fix: Preempting triggered an error because it still tried to set the goal as aborted.
  Also moved a lot of output to debug level or removed it completely.
* Piping through move_base result and feedback.
  Currently move_base does not publish a result though.
* Adapted human_aware_navigation to be used as navigation action server in topological map.
* Contributors: Bruno Lacerda, Christian Dondrup, cdondrup, strands
```
## strands_interaction_behaviours

```
* Removed calls to strands_head_orientation as those won't work in a release version.
* Merge branch 'hydro-devel' into release
  Conflicts:
  strands_hri_utils/scripts/set_voice.py
  strands_visualise_speech/scripts/visual_speech.py
* Moved utility scripts out of utils into corresponding packages.
* Typo
* Added license
* Prepared strands_interaction_behaviours for release
  Needs https://github.com/strands-project/strands_ui/pull/39 merged.
* Added missing webpage
* Renaming dependencies: ros_mary_tts is now mary_tts
* strands_perception_people_msgs has been removed
* Renamed ros_datacentre to mongodb_store
  This simply bulk replaces all ros_datacentre strings to mongodb_store strings inside files and also in file names.
  Needs strands-project/ros_datacentre#76 to be merged first.
* running head orientation while human_aware_navigation is running. Only if present. Changed default timeout of engaged server.
* Changing ques size and starting review action server in idle launch file
* Merge branch 'hydro-devel' of https://github.com/cdondrup/strands_hri into hydro-devel
* Renamed topic.
* Forgot a 'self'
* Bug fix
* added stop service call to preempt callback.
* Adding an action server for WP3/6 demo.
* Copy and paste error.
* Exposing parameters via launch file.
* More parameters to make more configurable
  Bug fix.
* Made idle behaviour more generic for review.
* Dialogue options for idle_nhm behaviour
* Mixed up z and y
* Using the titl motor tf to make the look around ignore the tilt value of the ptu but only take the pan.
* Adding orientation
* Switched coordinate frame for look around to ignore tilt values of ptu.
* Publish said sentences for nhm
* Setting initial gaze goal for the nav_goal
  resetting the mode in the behaviour switch to prevent it from looking away.
* Adding the possibility of disabling the looking around and speaking for the idle behaviour.
* Forgot to comment a call to create a page
* Some alteration taking out the webpages to make it more generic.
* Adding verbal output to signal that the behaviour was preempted and the robot will drive away now.
* Only creating the idle page when the engaed mode times out if the idle goal is still active.
* Fixing some web page issues and preempting
* 

    * 

* Changed spoken text.
* Removed the game and lights for now.
* Cancelling the executor goal if preempted.
* Adding the executor and removing the timeout for the engagedServer
* Added info behaviour. Only trigger for game is missing.
* Bug fixes
* Calling the right function for webpage.
* More typos.... It's getting late...
* Typo
* Added encoding info
* New webpage.
* renamed engagement_checker
* 

    * Create engagement action server to handle interaction after engagement was detected
    * Incorporated engagemant_checker in the system to trigger engagement_server
    * Moved magic numbers to parameters
    * Moved some output to debug level
    * Moved setting of voice for mary to top level server

* First version of idle behaviour for robot.
  Still needs:
  * Testing
  * Incorporation of engagement check
  * Reaction to engagement
  * PTU turning when error is fixed.
* Contributors: Christian Dondrup, Marc Hanheide, Nick Hawes, Rares Ambrus, ToMadoRe, cdondrup
```
## strands_simple_follow_me

```
* Prepared strands_simple_follow_me for release.
* Renamed pedestrian_tracker launch files
* strands_perception_people_launch is now called perception_people_launch
* Renamed strands_people_tracker to bayes_people_tracker
* strands_perception_people_msgs has been removed
* Adapting to new people_tracker message.
* Bugfix: Added missing *_generate_messages_cpp for the action servers.
* Using ${catkin_EXPORTED_TARGETS} in all packages for tyhe dependecies.
* Dependency bug corrected
* Added readme with a bit of explanation.
* Delete CMakeLists.txt.user
  Rubbish file from qtcreator
* Now uses the move_base server to plan a path to the human in front of it.
* Added convenience scale parameters for velocity and did some bug fixing which occured during velocity calculation.
* First attempt of a very simple follow me.
* Contributors: Christian Dondrup, Tom Krajnik, cdondrup
```
## strands_visualise_speech

```
* Fixing install process and launch file
  Preparing for release once strands_ui is released.
* Corrected a merge artifact.
* Merge branch 'hydro-devel' into release
  Conflicts:
  strands_hri_utils/scripts/set_voice.py
  strands_visualise_speech/scripts/visual_speech.py
* Move VisualSpeech.action into strands_visualise_speech package
* Moved visual_speech script into strands_visualise_speech package
* Prepared strands_visualise_speech for release.
* Update README.md
  Added warning.
* Update README.md
  Added usage and troubleshooting info.
* Stub readme's
* Renamed package
* Contributors: Christian Dondrup
```
