### PR TITLE
strands_hri: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7873,7 +7873,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_hri.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/strands-project/strands_hri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_hri` to `0.0.2-0`:
- upstream repository: https://github.com/strands-project/strands_hri.git
- release repository: https://github.com/strands-project-releases/strands_hri.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.1-0`
## strands_gazing
- No changes
## strands_hri_launch
- No changes
## strands_human_aware_navigation
- No changes
## strands_interaction_behaviours
- No changes
## strands_simple_follow_me
- No changes
## strands_visualise_speech

```
* Added code for pulseaudio directly
* Removed submodule
* Contributors: Christian Dondrup
```
