### PR TITLE
strands_executive: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7852,10 +7852,11 @@ repositories:
       - scheduler
       - scipoptsuite
       - strands_executive_msgs
+      - task_executor
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.4-0`
## scheduler

```
* CMake contains only public files, not those used for testing
* deleted to files, which are used only privately
* Now, tasks are replayed correctly from DB (previously, all tasks were the first one in DB)
* Supporting files, mainly used in experiments.
* Added documentation and deleted methods, which were not used anymore
* Changed pairs_new
* Edited CMakelist
* No backtracking algorithm, creating synthetic data
* creation of synthetic test - including 1,2,3,4 intervals
* still not working, it seems that constraint is not checked againts newly changed
* Added methods editExistingTcons, checkConstraint; not tested
* Added Original version of BC, my system uses also pre variables
* Contributors: Lenka Mudrova
```
## scipoptsuite
- No changes
## strands_executive_msgs
- No changes
## task_executor

```
* Added launch file install target and disabled testing.
* Moving task_executor to release branch.
* Contributors: Nick Hawes
```
