### PR TITLE
strands_webtools: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5693,10 +5693,16 @@ repositories:
       version: indigo-release
     status: developed
   strands_webtools:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_webtools.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/strands-project/strands_webtools.git
       version: hydro-devel
+    status: developed
   teleop_twist_joy:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_webtools` to `0.0.1-0`:
- upstream repository: https://github.com/strands-project/strands_webtools.git
- release repository: https://github.com/strands-project-releases/strands_webtools.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## strands_webtools

```
* moved webserver.sh
* Merge pull request #59 <https://github.com/strands-project/strands_webtools/issues/59> from ToMadoRe/hydro-devel
  Fixed missing build dependencies
* Fixed missing build dependencies
* Merge pull request #57 <https://github.com/strands-project/strands_webtools/issues/57> from kunzel/master
  added chatbot and updated visualization of stats
* updated stats visualization
* Merge branch 'master' of https://github.com/strands-project/strands_webtools
* added link to bob s chatbot
* Merge pull request #56 <https://github.com/strands-project/strands_webtools/issues/56> from kunzel/master
  added Bob's current tour info as it is also reported by Linda
* Merge branch 'master' of https://github.com/strands-project/strands_webtools
* added Bob s current tour info as also reported by Linda
* Merge pull request #55 <https://github.com/strands-project/strands_webtools/issues/55> from kunzel/master
  added a dynamic robot map based on the google maps api and a current status of topics (without using websockets)
* Merge branch 'master' of https://github.com/strands-project/strands_webtools
* added dynamic robot map and current status
* Merge pull request #54 <https://github.com/strands-project/strands_webtools/issues/54> from kunzel/master
  Updated latest version of Bob's homepage
* fixed conflict in bob.html
* added latest changes to bob s home page
* fixed line break
* fixed typo
* added static map for bham env
* fixed problem with video stream
* Merge branch 'master' of https://github.com/strands-project/strands_webtools
* removed unused parts; included twitter accounts
* Merge pull request #52 <https://github.com/strands-project/strands_webtools/issues/52> from kunzel/master
  Website for Bob
* added initial html page for bob
* cahnged submodule
* added command for loading apache modules
* Merge pull request #50 <https://github.com/strands-project/strands_webtools/issues/50> from strands-project/marathon
  Marathon: massive pull request with all the developments for the marathon
* Merge pull request #49 <https://github.com/strands-project/strands_webtools/issues/49> from marc-hanheide/marathon
  Marathon: making the marathon.html site configurable for different sites via CMake
* 

    * added gitignore for generated html files
    * removed outdated files
    * added generation of html pages according to cmake settings

* Merge branch 'marathon' of github.com:strands-project/strands_webtools into marathon
* added mjpeg_server params
* Update README.md
* Merge branch 'marathon' of github.com:strands-project/strands_webtools into marathon
* Merge branch 'marathon' of github.com:marc-hanheide/strands_webtools into marathon
* included safe mjpeg_server and adjusted topic
* corrected typo
* Merge pull request #48 <https://github.com/strands-project/strands_webtools/issues/48> from marc-hanheide/marathon
  Marathon as currently testing on http://lcas.lincoln.ac.uk/linda/marathon.html
* Update README.md
* Update README.md
* Merge branch 'marathon' of github.com:strands-project/strands_webtools into marathon
* now works at UOL
* Merge pull request #46 <https://github.com/strands-project/strands_webtools/issues/46> from marc-hanheide/marathon
  new file to launch the throttles on the robot for web publishing
* new file to launch the throttles on the robot for web publishing
* submodule
* Merge pull request #44 <https://github.com/strands-project/strands_webtools/issues/44> from marc-hanheide/marathon
  merge of most recent master changes into this branch
* Merge branch 'master' of github.com:strands-project/strands_webtools into marathon
* Merge pull request #41 <https://github.com/strands-project/strands_webtools/issues/41> from kunzel/master
  Swapped nav2djs submodule from kunzel/nav2djs to WPI-RAIL/nav2djs
* Merge pull request #43 <https://github.com/strands-project/strands_webtools/issues/43> from marc-hanheide/marathon
  removed robot_pose_publishers. fixes #42 <https://github.com/strands-project/strands_webtools/issues/42>
* removed robot_pose_publishers. fixes #42 <https://github.com/strands-project/strands_webtools/issues/42>
* added submodule WPI-RAIL/nav2djs
* deleted submodule kunzel/nav2djs
* Merge pull request #40 <https://github.com/strands-project/strands_webtools/issues/40> from marc-hanheide/marathon
  Marathon branch with safe rosbridge
* added marathon in index.html
* fixed path
* moved all apache specific files into the subdir as copies of the original ones with updates URIs
* reverted back to stand alone behaviour
* restructured to make it mergaeable with the master
* moved launch files
* Merge pull request #39 <https://github.com/strands-project/strands_webtools/issues/39> from marc-hanheide/apache_proxy
  I merge this myself, as it's only renaming things to work properly and only in this branch
* made it use the new rosbridge
* renamed and made it using the new rosbridge
* Merge pull request #38 <https://github.com/strands-project/strands_webtools/issues/38> from marc-hanheide/apache_proxy
  Apache proxy + new read-only version of rosbridge being used
* added mileage
* moved to linda/ namespace
* added RO version of webtools
* Update README.md
* Merge pull request #37 <https://github.com/strands-project/strands_webtools/issues/37> from marc-hanheide/apache_proxy
  some fixes to now work with the latest strands_morse
* 

    * added meta tag to stop browsers caching these pages
    * change to the mono camera
    * fixed the topics correctly

* Merge branch 'apache_proxy' of github.com:strands-project/strands_webtools into apache_proxy
* changed image topic to match head_xtion
* Merge pull request #36 <https://github.com/strands-project/strands_webtools/issues/36> from marc-hanheide/apache_proxy
  new webtools setup using Apache. Closes #34 <https://github.com/strands-project/strands_webtools/issues/34>
* added link to the original instructions
* Merge branch 'apache_proxy' of github.com:marc-hanheide/strands_webtools into apache_proxy
* disabled the simple webserver in the Apache setup
* simple script to build the wstunnel for Apache
* added the missing deps
* Update README.md
* completed instructions
* added instructions for installing apache modules
* stream-lined installation procedure with apache using cmake target "apache" and a new script
* now uses the proxied connection (all through port 80)
* change mjpeg port to not interfere with other services
* added mjpeg_server as dependency
* added missing css images
* fixed link
* added links
* Added info where to find topic_republisher (strands_utils)
* strands_utils -> topic_republisher
* Merge pull request #32 <https://github.com/strands-project/strands_webtools/issues/32> from kunzel/refactor-repo-structure
  Refactoring of repository structure
* added nav2djs submodule, adapted navigation.html
* included javascript files from submodules, removed obsolete javascript files
* added submodule for keyboardteleob
* added submodules for roslibjs, ros3djs, ros2djs and mjpegcanvasjs
* authors, license, changelog
* Merge pull request #30 <https://github.com/strands-project/strands_webtools/issues/30> from kunzel/nav-orientation
  Solves Issue #29 <https://github.com/strands-project/strands_webtools/issues/29>
* Merge branch 'master' of https://github.com/strands-project/strands_webtools into nav-orientation
* centered map view by default, updated click instruction
* Merge pull request #28 <https://github.com/strands-project/strands_webtools/issues/28> from kunzel/nav-orientation
  2D navigation with orientation
* fixed typo
* Merge branch 'master' of https://github.com/strands-project/strands_webtools into nav-orientation
* 2d map navigation with orientation
* removed weird character
* added additional dependencies
* Merge pull request #26 <https://github.com/strands-project/strands_webtools/issues/26> from hawesie/master
  Added keyboard controls to move 2D nav map around in the viewer.
* Merge remote-tracking branch 'upstream/master'
* Added scrolling of 2D map view.
* Merge pull request #25 <https://github.com/strands-project/strands_webtools/issues/25> from hawesie/master
  Added tf2_web_republisher to launch and added robot pose visualisation to main view
* Merge remote-tracking branch 'upstream/master'
* Added tf2_web_republisher to launch file to ensure link between web tf and real tf. This fixed the tf problem with the visualisation and closes #10 <https://github.com/strands-project/strands_webtools/issues/10>.
* Merge pull request #23 <https://github.com/strands-project/strands_webtools/issues/23> from hawesie/master
  Use robot_pose_publisher instead of the republisher I wrote. Also made this a valid catkin package.
* Made this a valid catkin package.
* Removed need for our own republisher.
  Instead relying on robot_pose_publisher which was designed to do this explicitly. See: https://github.com/WPI-RAIL/nav2djs/issues/26#issuecomment-20123090
* fixed typo
* Merge remote-tracking branch 'upstream/master'
* Merge pull request #22 <https://github.com/strands-project/strands_webtools/issues/22> from marc-hanheide/master
  now works also with remote access (not only localhost).
* Merge branch 'master' of github.com:strands-project/strands_webtools
* now works also with remote access (not only localhost).
* Merge pull request #19 <https://github.com/strands-project/strands_webtools/issues/19> from marc-hanheide/master
  added the republish_robot_pose node to the webtools launch file to get the entire webtools up and running at once
* Merge pull request #21 <https://github.com/strands-project/strands_webtools/issues/21> from kunzel/master
  added comment about the PTU joint state republisher
* added comment about the PTU joint state republisher
* added the https://github.com/marc-hanheide/strands_utils/blob/master/src/scripts/republish_robot_pose.py to the launch file
* Merge pull request #18 <https://github.com/strands-project/strands_webtools/issues/18> from kunzel/ptu-msg
  changed ptu msg from Vector3 (morse) to JointState (real robot)
* changed ptu msg from Vector3 (morse) to JointState (real robot)
* Merge pull request #17 <https://github.com/strands-project/strands_webtools/issues/17> from hawesie/master
  Added nodes on robot_pose for 2D nav view
* Merge remote-tracking branch 'upstream/master'
* Added comments on how to deal with robot pose. Fixes #12 <https://github.com/strands-project/strands_webtools/issues/12>.
* Merge pull request #15 <https://github.com/strands-project/strands_webtools/issues/15> from kunzel/ptu
  added teleop control for PTU
* added teleop control for PTU
* Cleaned up formatting errors for .rosinstall text.
* Removed unnecessary map file.
* Merge pull request #11 <https://github.com/strands-project/strands_webtools/issues/11> from marc-hanheide/master
  Initial version of a simple navigation widget to send the robot around in the 2D map
* added 2D navigation widget for autonomous navigation in the map
* added *~ to gitignore
* Merge pull request #8 <https://github.com/strands-project/strands_webtools/issues/8> from kunzel/master
  added 3d map and pose to main view
* Update README.md
* added pose to main view
* Merge branch 'master' of https://github.com/strands-project/strands_webtools
* added 3D map to main view
* Merge pull request #7 <https://github.com/strands-project/strands_webtools/issues/7> from marc-hanheide/master
  Launch file for webtools in strands
* added launch file. fixes #4 <https://github.com/strands-project/strands_webtools/issues/4>. also added a simple static index.html
* Merge pull request #3 <https://github.com/strands-project/strands_webtools/issues/3> from hawesie/master
  Added additional page plus updated read me
* Added run instructions.
* Refactored a little and added map page.
  Map page may not be necessary if we include on page with camera as discussed.
* added more dependencies to README
* Merge pull request #2 <https://github.com/strands-project/strands_webtools/issues/2> from kunzel/master
  added keyboard control and robot cam view
* added keyboard control and robot cam view
* Merge pull request #1 <https://github.com/strands-project/strands_webtools/issues/1> from hawesie/master
  Links in README
* adding some links for marc
* Initial commit
* Contributors: Lars Kunze, Marc Hanheide, Nick Hawes, Webuser, mailto:thomas.faeulhammer@tuwien.ac.at
```
