### PR TITLE
scitos_common: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7301,7 +7301,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_common.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_common` to `0.1.2-0`:
- upstream repository: https://github.com/strands-project/scitos_common.git
- release repository: https://github.com/strands-project-releases/scitos_common.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.1-0`
## scitos_common
- No changes
## scitos_description

```
* [scitos_common] fixing run dependencies
  Fixing #43
* Contributors: Christian Dondrup
```
## scitos_msgs
- No changes
