### PR TITLE
strands_apps: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5627,6 +5627,7 @@ repositories:
     release:
       packages:
       - door_pass
+      - odometry_mileage
       - pose_extractor
       - ramp_climb
       - reconfigure_inflation
@@ -5635,7 +5636,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_apps.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/strands_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.4-0`
## door_pass
- No changes
## odometry_mileage

```
* [odometry_mileage] making it robot independent and prepared for release
  * Added timeout if there is no mileage topic to read the initial value from.
  * configurable via parameter
  * Topic from which to read the initial mileage is now configurable
* Moving odometry_mileage HERE (sorry for the misunderstanding @cdondrup)
* Contributors: Christian Dondrup, Jaime Pulido Fentanes
* [odometry_mileage] making it robot independent and prepared for release
  * Added timeout if there is no mileage topic to read the initial value from.
  * configurable via parameter
  * Topic from which to read the initial mileage is now configurable
* Moving odometry_mileage HERE (sorry for the misunderstanding @cdondrup)
* Contributors: Christian Dondrup, Jaime Pulido Fentanes
```
## pose_extractor
- No changes
## ramp_climb
- No changes
## reconfigure_inflation
- No changes
## state_checker
- No changes
## topic_republisher
- No changes
