### PR TITLE
strands_morse: 0.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7914,7 +7914,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.0.6-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.5-0`
## strands_morse

```
* Merge pull request #80 <https://github.com/strands-project/strands_morse/issues/80> from cdondrup/human
  Using the standard morse human model
* Updated README with install and set-up instructions using the morse-blender-bundle
* Switched to standard human model
* Merge pull request #78 <https://github.com/strands-project/strands_morse/issues/78> from cdondrup/hydro-devel
  Fixing the "stuck in the ground" bug.
* Fixing the stuck in the ground bug.
  fixing #77 <https://github.com/strands-project/strands_morse/issues/77>
  I the UoL environments the robot started at z = 0.0 which sometimes let it start in the ground and prevented movement.
* Contributors: Christian Dondrup, Marc Hanheide
```
