### PR TITLE
openni_wrapper: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4798,10 +4798,16 @@ repositories:
       version: 0.2.0-1
     status: maintained
   openni_wrapper:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/openni_wrapper.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/strands-project/openni_wrapper.git
       version: hydro-devel
+    status: developed
   openrtm_aist_core:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_wrapper` to `0.0.2-0`:
- upstream repository: https://github.com/strands-project/openni_wrapper.git
- release repository: https://github.com/strands-project-releases/openni_wrapper.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## openni_wrapper

```
* changed path for new OpenNI2 submodule
* added new location
* Added install rules for OpenNI2 and updated openni_wrapper to use installed library
* Added license file and fixed library install
* Changed license to Apache v2.0
* Added glut dependency
* Added java dependency
* changed libusb dependency to something rosdep can find
* Fixed libusb dependency name
* Added libusb as a dependency
* Removed ros-hydro-opencv2 dependency from package.xml
* Fixed maintainer name and added some dependencies in package.xml
* Enabling hardware registration
* Moved openni files to root openni_folder
* Contributors: Marc Hanheide, Rares Ambrus
```
