### PR TITLE
openni_wrapper: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4805,7 +4805,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/openni_wrapper.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/strands-project/openni_wrapper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_wrapper` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/openni_wrapper.git
- release repository: https://github.com/strands-project-releases/openni_wrapper.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## openni_wrapper

```
* Merge pull request #10 <https://github.com/strands-project/openni_wrapper/issues/10> from RaresAmbrus/hydro-devel
  Re-arranged folder structure of openni_wrapper
* Removed unnecessary 3rd party folder. Not needed in the release branch
* Setup new submodule path
* removing old .gitmodules
* Changed OpenNI2 submodule path
* Removed empty openni_wrapper folder
* Moved contents of openni_wrapper folder one level up
* Contributors: Rares Ambrus, RaresAmbrus
```
