### PR TITLE
metapackages: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3671,10 +3671,19 @@ repositories:
       version: groovy-devel
     status: maintained
   metapackages:
+    release:
+      packages:
+      - strands_desktop
+      - strands_robot
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/metapackages.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/strands-project/metapackages.git
       version: hydro-devel
+    status: maintained
   microstrain_3dmgx2_imu:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `0.0.2-0`:
- upstream repository: https://github.com/strands-project/metapackages.git
- release repository: https://github.com/strands-project-releases/metapackages.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## strands_desktop

```
* corretc morse rosdep key
* changed - to _
* made it STRANDS specific
* made strands-specific
* Contributors: Marc Hanheide
```
## strands_robot

```
* added more packages
* changed - to _
* made it STRANDS specific
* made strands-specific
* Contributors: Marc Hanheide
```
