### PR TITLE
strands_social: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8005,11 +8005,12 @@ repositories:
       - datamatrix_read
       - fake_camera_effects
       - image_branding
+      - social_card_reader
       - strands_tweets
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_social.git
-      version: 0.0.4-2
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/strands_social.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_social` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/strands_social.git
- release repository: https://github.com/strands-project-releases/strands_social.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.4-2`
## datamatrix_read
- No changes
## fake_camera_effects
- No changes
## image_branding
- No changes
## social_card_reader

```
* Install targets added and redundant dependencies removed.
* CDump removed to resolve dependency on NCURSES.
* Brief README + card improvement
* Distance verification to remove outliers.
* Improved cards.
* Addded classes to calculate position of the pattern in space.
* Added cards.
* Circle detector social card reader.
* Circle detector social card reader.
* Circle detector to read command cards.
* Contributors: Tom Krajnik, strands
* Install targets added and redundant dependencies removed.
* CDump removed to resolve dependency on NCURSES.
* Brief README + card improvement
* Distance verification to remove outliers.
* Improved cards.
* Addded classes to calculate position of the pattern in space.
* Added cards.
* Circle detector social card reader.
* Circle detector social card reader.
* Circle detector to read command cards.
* Contributors: Tom Krajnik, strands
```
## strands_tweets
- No changes
