### PR TITLE
strands_webtools: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8036,7 +8036,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_webtools.git
-      version: 0.0.1-1
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/strands-project/strands_webtools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_webtools` to `0.0.2-0`:
- upstream repository: https://github.com/strands-project/strands_webtools.git
- release repository: https://github.com/strands-project-releases/strands_webtools.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.1-1`
## strands_webtools

```
* merged #62 <https://github.com/strands-project/strands_webtools/issues/62>
* Merge pull request #60 <https://github.com/strands-project/strands_webtools/issues/60> from cdondrup/hydro-devel
  strands_pedestrian_tracking has been renamed to mdl_people_tracker
* strands_pedestrian_tracking has been renamed to mdl_people_tracker
* Contributors: Christian Dondrup, Marc Hanheide
```
