### PR TITLE
openni_wrapper: 0.0.4-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -4814,7 +4814,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/openni_wrapper.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/strands-project/openni_wrapper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_wrapper` to `0.0.4-0`:
- upstream repository: https://github.com/strands-project/openni_wrapper.git
- release repository: https://github.com/strands-project-releases/openni_wrapper.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-0`
## openni_wrapper

```
* Merge pull request #11 <https://github.com/strands-project/openni_wrapper/issues/11> from RaresAmbrus/hydro-devel
  Removed OpenNI2 submodule and replaced with subtree
* Merge commit '5b17aecf313fe4fd0f14e382f8ee6dfb4b60a409' as 'OpenNI2'
* Squashed 'OpenNI2/' content from commit 115cf06
  git-subtree-dir: OpenNI2
  git-subtree-split: 115cf06c6efea32304182d293eca16ca883c9150
* Removed openni2 submodule
* Removed openni2 submodule
* Contributors: Marc Hanheide, Rares Ambrus
```
