### PR TITLE
strands_navigation: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7956,17 +7956,17 @@ repositories:
   strands_navigation:
     release:
       packages:
+      - joy_map_saver
       - message_store_map_switcher
       - monitored_navigation
       - strands_navigation
       - strands_navigation_msgs
-      - topological_map_manager
       - topological_navigation
       - topological_utils
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.4-0`
## joy_map_saver

```
* adding install targets renaming executables
* bug fix
* Adding licences and bug fix
* moving joy map saver here
* Contributors: Jaime Pulido Fentanes
* adding install targets renaming executables
* bug fix
* Adding licences and bug fix
* moving joy map saver here
* Contributors: Jaime Pulido Fentanes
```
## message_store_map_switcher

```
* Adding licences and bug fix
* Contributors: Jaime Pulido Fentanes
```
## monitored_navigation

```
* Adding licences and bug fix
* edited readme
* code cleaning
* created strands-specific launch file
* monitors and recoveries can only be added when action server is not running
  Signed-off-by: Bruno Lacerda <mailto:b.lacerda@cs.bham.ac.uk>
* edit readme (to be extended later)
* added service definitions for adding and removing monitor and help states to the overall monitored nav state machine
* Merge branch 'hydro-devel' of https://github.com/strands-project/strands_navigation into hydro-devel
* added strands specific config yaml
* monitor and recovery states are now defined via a config yaml file.
* Merge branch 'target' into hydro-devel
  Conflicts:
  monitored_navigation/CMakeLists.txt
* adding monitored nav launch to targets
* Contributors: Bruno Lacerda, Jaime Pulido Fentanes
```
## strands_navigation
- No changes
## strands_navigation_msgs

```
* Adding licences and bug fix
* Removed topological_utils dependency.
* Moved Vertex and Edge into strands_navigation_msgs.
  Basic test for travel_time_tester passes.
* Merge topological_navigation and topological_map_manager packages.
  Added the EstimateTravelTime service to provide a clean way of getting travel times of the topological map.
* added service definitions for adding and removing monitor and help states to the overall monitored nav state machine
* Contributors: Bruno Lacerda, Jaime Pulido Fentanes, Nick Hawes
```
## topological_navigation

```
* adding joystick creation of topological map
* Added dummy script to stand in for topological navigation when missing a robot or proper simulation.
  Useful for testing.
* Adding licences and bug fix
* Added launch file for test, and test passing locally.
* Moved Vertex and Edge into strands_navigation_msgs.
  Basic test for travel_time_tester passes.
* Added travel_time_estimator to standard launch file.
* Merge topological_navigation and topological_map_manager packages.
  Added the EstimateTravelTime service to provide a clean way of getting travel times of the topological map.
* Contributors: Jaime Pulido Fentanes, Nick Hawes
```
## topological_utils

```
* Merge branch 'hydro-devel' of https://github.com/strands-project/strands_navigation into hydro-devel
  Conflicts:
  topological_utils/CMakeLists.txt
* adding install targets
* adding joystick creation of topological map
* Added launch file for dummy topological navigation and install targets.
* Added dummy script to stand in for topological navigation when missing a robot or proper simulation.
  Useful for testing.
* Adding licences and bug fix
* Moved Vertex and Edge into strands_navigation_msgs.
  Basic test for travel_time_tester passes.
* Contributors: Jaime Pulido Fentanes, Nick Hawes
```
