### PR TITLE
strands_social: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5877,6 +5877,23 @@ repositories:
       url: https://github.com/strands-project/strands_perception_people.git
       version: indigo-release
     status: developed
+  strands_social:
+    release:
+      packages:
+      - datamatrix_read
+      - fake_camera_effects
+      - image_branding
+      - social_card_reader
+      - strands_tweets
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_social.git
+      version: 0.0.5-0
+    source:
+      type: git
+      url: https://github.com/strands-project/strands_social.git
+      version: hydro-devel
+    status: developed
   strands_ui:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_social` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/strands_social.git
- release repository: https://github.com/strands-project-releases/strands_social.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## datamatrix_read
- No changes
## fake_camera_effects
- No changes
## image_branding
- No changes
## social_card_reader

```
* Install targets added and redundant dependencies removed.
* CDump removed to resolve dependency on NCURSES.
* Brief README + card improvement
* Distance verification to remove outliers.
* Improved cards.
* Addded classes to calculate position of the pattern in space.
* Added cards.
* Circle detector social card reader.
* Circle detector social card reader.
* Circle detector to read command cards.
* Contributors: Tom Krajnik, strands
* Install targets added and redundant dependencies removed.
* CDump removed to resolve dependency on NCURSES.
* Brief README + card improvement
* Distance verification to remove outliers.
* Improved cards.
* Addded classes to calculate position of the pattern in space.
* Added cards.
* Circle detector social card reader.
* Circle detector social card reader.
* Circle detector to read command cards.
* Contributors: Tom Krajnik, strands
```
## strands_tweets
- No changes
