### PR TITLE
mongodb_store: 0.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2764,7 +2764,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.6-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.5-0`
## mongodb_log
- No changes
## mongodb_store

```
* Launch file to right place this time.
  It seems like the syntax is doing different things in different CMake files though.
* fixing launch file order
* Merge branch 'hydro-devel' of https://github.com/strands-project/mongodb_store into hydro-devel
  Conflicts:
  mongodb_store/launch/mongodb_store.launch
* replacing env for optenv
* Fixed spacing and author info
* Changing launch file to adjust to new machine tag type
* Changing launch file to adjust to new machine tag type
* Contributors: Jailander, Jaime Pulido, Jaime Pulido Fentanes, Nick Hawes
```
## mongodb_store_msgs
- No changes
