### PR TITLE
strands_apps: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5802,12 +5802,13 @@ repositories:
       - pose_extractor
       - ramp_climb
       - reconfigure_inflation
+      - roslaunch_axserver
       - state_checker
       - topic_republisher
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_apps.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/strands-project/strands_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.0.6-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.5-0`
## door_pass
- No changes
## odometry_mileage
- No changes
## pose_extractor
- No changes
## ramp_climb
- No changes
## reconfigure_inflation
- No changes
## roslaunch_axserver

```
* added license and bumped version
* added test and install targets
* Add 'roslaunch_axserver/' from commit '769ad1b36aba0562dbc948d122095dd7d44a291e'
  git-subtree-dir: roslaunch_axserver
  git-subtree-mainline: c16409abfa4f28546961d5115e6abbec0b2a3068
  git-subtree-split: 769ad1b36aba0562dbc948d122095dd7d44a291e
* Contributors: Marc Hanheide
* added license and bumped version
* added test and install targets
* Add 'roslaunch_axserver/' from commit '769ad1b36aba0562dbc948d122095dd7d44a291e'
  git-subtree-dir: roslaunch_axserver
  git-subtree-mainline: c16409abfa4f28546961d5115e6abbec0b2a3068
  git-subtree-split: 769ad1b36aba0562dbc948d122095dd7d44a291e
* Contributors: Marc Hanheide
```
## state_checker
- No changes
## topic_republisher
- No changes
