### PR TITLE
scitos_drivers: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7358,7 +7358,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_drivers.git
-      version: 0.0.2-3
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_drivers` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/scitos_drivers.git
- release repository: https://github.com/strands-project-releases/scitos_drivers.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-3`
## flir_pantilt_d46

```
* attempt to fix #67 <https://github.com/strands-project/scitos_drivers/issues/67> by adding install target
* Contributors: Marc Hanheide
```
## scitos_drivers
- No changes
## scitos_mira

```
* added rpath
* Contributors: Marc Hanheide
```
