### PR TITLE
scitos_apps: 0.0.6-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7319,6 +7319,7 @@ repositories:
   scitos_apps:
     release:
       packages:
+      - scitos_apps
       - scitos_cmd_vel_mux
       - scitos_dashboard
       - scitos_docking
@@ -7328,7 +7329,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_apps.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_apps` to `0.0.6-0`:
- upstream repository: https://github.com/strands-project/scitos_apps.git
- release repository: https://github.com/strands-project-releases/scitos_apps.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.5-0`
## scitos_apps

```
* Added license
* Created metapackage for easier install
* Contributors: Christian Dondrup
* Added license
* Created metapackage for easier install
* Contributors: Christian Dondrup
```
## scitos_cmd_vel_mux
- No changes
## scitos_dashboard
- No changes
## scitos_docking
- No changes
## scitos_ptu
- No changes
## scitos_teleop
- No changes
## scitos_touch
- No changes
