### PR TITLE
strands_apps: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5804,11 +5804,12 @@ repositories:
       - reconfigure_inflation
       - roslaunch_axserver
       - state_checker
+      - strands_apps
       - topic_republisher
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_apps.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/strands-project/strands_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.0.7-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.6-0`
## door_pass
- No changes
## odometry_mileage
- No changes
## pose_extractor
- No changes
## ramp_climb
- No changes
## reconfigure_inflation
- No changes
## roslaunch_axserver
- No changes
## state_checker
- No changes
## strands_apps

```
* Created metapackage for easier install
* Contributors: Christian Dondrup
* Created metapackage for easier install
* Contributors: Christian Dondrup
```
## topic_republisher
- No changes
