### PR TITLE
strands_social: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5893,11 +5893,12 @@ repositories:
       - fake_camera_effects
       - image_branding
       - social_card_reader
+      - strands_social
       - strands_tweets
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_social.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/strands-project/strands_social.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_social` to `0.0.6-0`:
- upstream repository: https://github.com/strands-project/strands_social.git
- release repository: https://github.com/strands-project-releases/strands_social.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.5-0`
## datamatrix_read
- No changes
## fake_camera_effects
- No changes
## image_branding
- No changes
## social_card_reader
- No changes
## strands_social

```
* Added social_card_reader
* Created metapackage for easier install
* Contributors: Christian Dondrup
* Added social_card_reader
* Created metapackage for easier install
* Contributors: Christian Dondrup
```
## strands_tweets
- No changes
