### PR TITLE
metapackages: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3678,7 +3678,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/metapackages.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/strands-project/metapackages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/metapackages.git
- release repository: https://github.com/strands-project-releases/metapackages.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## strands_desktop

```
* Added strands_apps, scitos_apps, strands_socil, and strands_hri to robot and desktop metapackages.
* Contributors: Christian Dondrup
```
## strands_robot

```
* Added strands_apps, scitos_apps, strands_socil, and strands_hri to robot and desktop metapackages.
* Contributors: Christian Dondrup
```
