### PR TITLE
strands_executive: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5826,7 +5826,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.6-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.5-0`
## scheduler

```
* Restored missing code.
* Added tests for scheduler.
* Pushed duration service argument through C++ side.
* Contributors: Nick Hawes
```
## scipoptsuite
- No changes
## strands_executive_msgs

```
* Added tests for scheduler.
* Pushed duration service argument through C++ side.
* Contributors: Nick Hawes
```
## task_executor

```
* Updated and tested FIFO executor. Removed MDP depedency from base executor.
  This is now ready for a full release without the MDP parts.
* Contributors: Nick Hawes
```
