### PR TITLE
fremen: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1856,6 +1856,15 @@ repositories:
       version: master
     status: maintained
   fremen:
+    release:
+      packages:
+      - fremengrid
+      - frenap
+      - froctomap
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/fremen.git
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/strands-project/fremen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fremen` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/fremen.git
- release repository: https://github.com/strands-project-releases/fremen.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
