### PR TITLE
fremen: 0.0.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1864,7 +1864,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/fremen.git
-      version: 0.0.3-0
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/strands-project/fremen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fremen` to `0.0.3-1`:
- upstream repository: https://github.com/strands-project/fremen.git
- release repository: https://github.com/strands-project-releases/fremen.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-0`
