### PR TITLE
strands_executive: 0.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7934,7 +7934,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.7-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.6-0`
## scheduler
- No changes
## scipoptsuite
- No changes
## strands_executive_msgs
- No changes
## task_executor

```
* Moving scripts to the install target rather than setup.py and the latter doesn't install them under the package name.
  Conflicts:
  task_executor/CMakeLists.txt
* Contributors: Nick Hawes
```
