### PR TITLE
strands_morse: 0.0.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7967,7 +7967,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.0.8-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.7-0`
## strands_morse

```
* Merge pull request #89 from cdondrup/dependencies
  Adding scitos_2d_navigation as run_depend
* Merge pull request #88 from cdondrup/no-cameras
  Added several environments without cameras to speed up simulation
* Adding scitos_2d_navigation as run_depend
  Fixing #87
* Merge pull request #86 from cdondrup/dependencies
  Reintroducing morse-blender-bundle as run_depend
* 

    * Added human_pose_simulator to launch file
    * Small changes to human_pose_simulator to work with and without semantic camera
    * in wire frame mode the semantic camera doesn't really work. Therefor visible defaults to true if there is no semantic cam info coming in.
    * moved output to debug.

* Adding several uol environments without cameras to make simulation quicker.
* Reintroducing morse-blender-bundle as run_depend
  Fixing #84
* Contributors: Christian Dondrup
```
