### PR TITLE
fremen: 0.1.0-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1864,7 +1864,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/fremen.git
-      version: 0.0.3-2
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/strands-project/fremen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fremen` to `0.1.0-0`:
- upstream repository: https://github.com/strands-project/fremen.git
- release repository: https://github.com/strands-project-releases/fremen.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-2`
## fremengrid

```
* Packages improved.
* Contributors: Tom Krajnik
```
## frenap

```
* Actionlib generate messages
* Packages improved.
* Contributors: Tom Krajnik
```
## froctomap

```
* Packages improved.
* Contributors: Tom Krajnik
```
