### PR TITLE
strands_apps: 0.0.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7921,7 +7921,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_apps.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/strands-project/strands_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.0.8-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.7-0`
## door_pass

```
* final and tested version of loader
* new machine tags
* Contributors: Jaime Pulido Fentanes
```
## odometry_mileage
- No changes
## pose_extractor
- No changes
## ramp_climb

```
* final and tested version of loader
* new machine tags
* Contributors: Jaime Pulido Fentanes
```
## reconfigure_inflation
- No changes
## roslaunch_axserver
- No changes
## state_checker
- No changes
## strands_apps
- No changes
## topic_republisher
- No changes
