### PR TITLE
scitos_apps: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5379,7 +5379,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_apps.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_apps` to `0.0.7-0`:
- upstream repository: https://github.com/strands-project/scitos_apps.git
- release repository: https://github.com/strands-project-releases/scitos_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.6-0`
## scitos_apps
- No changes
## scitos_cmd_vel_mux

```
* final and tested version of loader
* machine tags for cmd_vel_mux and teleop
* Contributors: Jaime Pulido Fentanes
```
## scitos_dashboard
- No changes
## scitos_docking

```
* final and tested version of loader
* Latest Versions of charging launch machine tags
* Contributors: Jaime Pulido Fentanes
```
## scitos_ptu
- No changes
## scitos_teleop

```
* final and tested version of loader
* machine tags for cmd_vel_mux and teleop
* Contributors: Jaime Pulido Fentanes
```
## scitos_touch
- No changes
