### PR TITLE
scitos_drivers: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7377,7 +7377,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_drivers.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_drivers` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/scitos_drivers.git
- release repository: https://github.com/strands-project-releases/scitos_drivers.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.4-0`
## flir_pantilt_d46

```
* final and tested version of loader
* new machine tag format
* added new machine tags to ptu launch file
* Contributors: Jaime Pulido Fentanes
```
## scitos_drivers
- No changes
## scitos_mira

```
* final and tested version of loader
* new machine tag format
* scitos_mira.launch with new machine tags
* Contributors: Jaime Pulido Fentanes, strands
```
