### PR TITLE
strands_recovery_behaviours: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8031,10 +8031,21 @@ repositories:
       version: hydro-devel
     status: developed
   strands_recovery_behaviours:
+    release:
+      packages:
+      - backtrack_behaviour
+      - strands_human_help
+      - strands_monitored_nav_states
+      - strands_recovery_behaviours
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_recovery_behaviours.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/strands-project/strands_recovery_behaviours.git
       version: hydro-devel
+    status: developed
   strands_social:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_recovery_behaviours` to `0.0.1-0`:
- upstream repository: https://github.com/strands-project/strands_recovery_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_recovery_behaviours.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## backtrack_behaviour

```
* Merge remote-tracking branch 'upstream/hydro-devel' into hydro-devel
* Changed to the correct topic
* backtrack server now waits for SetPTUState and move_base
* Removed unnecessary dependencies and corrected an include bug
* Added the correct paths in backtrack_server.py
* Fixed the message namespaces
* Now the backtrack_server.py is executable after installing
* Added install targets for backtrack_behaviour package
* Launching the correct nodes in the launch file
* Got it to compile
* Integrated previous_positions_service and republish_pointcloud_service into backtrack_behaviour package
* moving backtrack related packages here
* Contributors: Bruno Lacerda, Nils Bore
```
## strands_human_help

```
* only say thank you when you're helped
* merging nav help speech and nav help screen to a single package
  total rewrite of the classes in order to make their addition and removal to monitored nav similar to the recovery behaviours
* Contributors: Bruno Lacerda
```
## strands_monitored_nav_states

```
* using new AskHelp srv definition
* renaming smach recoveries package
* Contributors: Bruno Lacerda
```
## strands_recovery_behaviours

```
* moving mon nav config and launch files here
* renaming smach recoveries package
* fixing imports + sending number of fails when asking for help
* update dependencies
* small bug fix
* logging pauses - user taking over with gamepad or pause service calls - to mongodb
* adding mongo logging for backtrack recovery
* publishing recovery events to a topic
* waiting for backtrack action
* using param server for the recovery parameters
* update package.xml and CMakeLists.txt
* re-adding possibility of pausing monitored navigation via gamepad or service call
* moving human_help_manager service definition to human_help_manager package
* removing monitored nav readme
* removing monitored_navigation filesthat shoundlnt be here
* implementation of recovery state machines for monitored navigation
* Contributors: Bruno Lacerda
```
