### PR TITLE
robblog: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -5915,6 +5915,17 @@ repositories:
       url: https://github.com/robotican/ric.git
       version: hydro-devel
     status: maintained
+  robblog:
+    release:
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/robblog.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/strands-project/robblog.git
+      version: hydro-devel
+    status: developed
   robot_localization:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `robblog` to `0.0.1-0`:
- upstream repository: https://github.com/strands-project/robblog.git
- release repository: https://github.com/strands-project-releases/robblog.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## robblog

```
* Added seconds to robblog title.
* Added seconds to robblog timed entry title.
* Adding nodejs to required dependencies
* Added useful function to create posts with time in the title.
* Working version, tested on a separate install.
* Markdown generated from entries from datacentre.
* Added basic site creation and serving
* Contributors: Bruno Lacerda, Chris Burbridge, Christian Dondrup, Marc Hanheide, Nick Hawes
```
