### PR TITLE
strands_3d_mapping: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7913,6 +7913,17 @@ repositories:
       url: https://github.com/srv/stereo_slam.git
       version: hydro
   strands_3d_mapping:
+    release:
+      packages:
+      - cloud_merge
+      - ekz_public_lib
+      - metaroom_xml_parser
+      - scitos_ptu_sweep
+      - semantic_map
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_3d_mapping.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/strands-project/strands_3d_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_3d_mapping` to `0.0.1-0`:
- upstream repository: https://github.com/strands-project/strands_3d_mapping.git
- release repository: https://github.com/strands-project-releases/strands_3d_mapping.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## cloud_merge

```
* Removed ability to process input point clouds. Using images to generate the point clouds
* Logging intermediate data to the database disabled by default
* Saving intermediate data enabled by default
* removed input point cloud topic in the launch file. Not supported anymore as images are used as input directly
* reorganized the code into additional methods
* Some error checking
* changes from upstream
* Added image_transport as a dependency
* Fixed qt_build and qt_ros dependencies
* Removed package dependency on cloud_register
* Removed unnecessary dependency on cloud_register
* Fixed pcl dependency
* Set up install targets for cloud_merge
* removed unnecessary file
* Changed qt dependency
* Fixed license and maintainer email
* Fixed mongodb dependency
* Added dependency to message generation
* First verison of mongodb dependency
* merge from upstream
* Renamed ros_datacentre to mongodb_store
* Changed some methods to static
* Added flag -mno-avx to tackle assembler errors during compiling on some new Intel core processors
* Added launch file parameters for the table top voxel size, observation voxel size and a parameter for the point distance cutoff. Also added a parameter to specify whether to update the metarooms with new room observations
* merged commit
* Added another stream containing the downsampled observation point cloud and changed the size of the voxel grid to get smaller observation point clouds
* Merge branch 'hydro-devel' of https://github.com/RaresAmbrus/scitos_3d_mapping into hydro-devel
* Added services for waypoint based querying of observations, dynamic clusters and metarooms
* Merge remote-tracking branch 'upstream/hydro-devel' into hydro-devel
  Conflicts:
  semantic_map/launch/mapping.launch
* Changed the number of observations to 5
* Added ftp upload action server to the launch file
* respawn set to true
* Launch parameter to cache or delete old data
* Added function to move old data to a cache folder instead of deleting it
* Handling preemption of the pan tilt sweep
* Added a launch file parameter for saving to the database and fixed a bug.
* Logging intermediate point clouds to the database. Logging dynamic clusters to the database
* Handling the case when the observation point cloud is empty - should only happen if the camera isn't running
* Automatically deducing the patrol run number and room id based on previously saved data
* Added max number of instances per observation as a launch file parameters and made cleanup of the saved semantic map information false by default in the launch file
* Added functionality to check how many instances of an observation have been saved, and remove some of them if there are too many
* Changed types of launch file parameters to bool
* Added launch file paremters to specify ros topics for input point cloud, input rgb image, input depth image and input camera info
* Added launch file parameter generate_pointclouds for cloud_merge node specifying whether to use the RGBD images from the sensor to generate point clouds or whether to use the point clouds generate by the openni driver directly
* Modification to use intermediate point clouds instead of generating them from RGBD images
* Added ros-hydro-qt-build as a dependency in package.xml and updated the readme.
* Added functionality to remove previously saved metric map data, which can be set via the launch parameter cleanup (yes/no). The default behavior atm is to delete previously saved data, i.e. all metarooms will be created from scratch. This does not affect the creation of individual room observations
* Changed the voxel grid cell size to 1cm for downsampling the merged point cloud
* Downsampling of observation point cloud using a 2cm voxel grid instead of 0.5 cm
* Added launch file parameters for configuring the saving of intermediate data (would be used fro debugging purposes)
* launch files
* Local metric map nodes: cloud_merge - processing depth & rgb frames / point clouds and merging them into room observations; cloud_register - utilities for ICP and NDT point cloud registration; semantic_map - creating and managing the local metric map, updating the map with new room observations, extracting dynamic clusters, maintaining the XML structure on the disk.
* Contributors: Johan Ekekrantz, Linda's sidekick, Nick Hawes, Rares Ambrus, cburbridge, cvapdemo, mailto:thomas.faeulhammer@tuwien.ac.at
```
## ekz_public_lib

```
* keeping upstream package.xml
* changes to package.xml
* changes from upstream
* moved headers to /include
* removed some example data to reduce packagesize
* Fixed type in pcl dependency
* Fixed pcl dependency
* Corrected opencv dependency in ekz registration
* Added flag -mno-avx to tackle assembler errors during compiling on some new Intel core processors
* change package name to follow naming conventions
* Fixed bug in CMakelists
* Initial commit for ekz public lib
* Contributors: Johan Ekekrantz, Rares Ambrus, johane, mailto:thomas.faeulhammer@tuwien.ac.at
```
## metaroom_xml_parser

```
* Added readme
* renaming
* Contributors: Rares Ambrus
```
## scitos_ptu_sweep

```
* Merge pull request #46 <https://github.com/strands-project/strands_3d_mapping/issues/46> from Jailander/hydro-devel
  Preparing scitos_ptu_sweep for release
* Preparing scitos_ptu_sweep for release
* changes from upstream
* Using wait_for_message instead of subscribing then publishing
* adding JointState republish
* Adding sweep_save changes
* adding sweep_save
* Adding current node republishing
* Adding republishing registered point clouds
* adding machine tags to PTU Sweep.launch and subscribing only when action server is executed and unregistering once is finished
* bug fix
* Adding Image replushing on PTUSweep
* "pcl is no longer packaged by the ROS community as a catkin package" (see http://wiki.ros.org/hydro/Migration#PCL)
* modification suggested to resolve https://github.com/strands-project/strands_ci/issues/8
* Last version of the PTU sweep script the sweep is done horizontally and the ptu doesn't go back to the begining of each scanning angle
* Added Launch File
* Fixed bugs produced by changing names
* Changed name to follow naming conventions
* Contributors: Jaime Pulido Fentanes, Johan Ekekrantz, Lars Kunze, Marc Hanheide, strands
```
## semantic_map

```
* removed launching of the ftp upload action server
* removed launching of the ftp upload action server
* Fixed method for detecting oldest rooms in the cache
* Changed room centroid distance to 1m
* Added image_geometry dependency
* Added saving of camera parameters
* changes from upstream
* Fixed qt_build and qt_ros dependencies
* Removed package dependency on cloud_register
* removed dependency on cloud_register package
* Added ndt registration wrapper in the semantic_map package
* Fixed pcl dependency
* Added install targets for semantic_map and cloud_register
* Changed qt dependency
* Fixed license and maintainer email
* Fixed mongodb dependency
* First verison of mongodb dependency
* merge from upstream
* Renamed ros_datacentre to mongodb_store
* Bugfixing, mostly about saving and loading metaroom data
* Added flag -mno-avx to tackle assembler errors during compiling on some new Intel core processors
* More colors for dynamic clusters
* Merge branch 'hydro-devel' of https://github.com/RaresAmbrus/scitos_3d_mapping into hydro-devel
* Publishing the clustered differences with difference colors. Also made the publishers latching - i.e. they will republish the last published message to each new subscriber
* Y1Review working changes
* Saving pcd files only if they don't exist already (only for rooms, not for metarooms)
* Saving dynamic clusters in the room xml file and as a pcd file
* Added launch file parameters for the table top voxel size, observation voxel size and a parameter for the point distance cutoff. Also added a parameter to specify whether to update the metarooms with new room observations
* merged commit
* Added another stream containing the downsampled observation point cloud and changed the size of the voxel grid to get smaller observation point clouds
* Added services for waypoint based querying of observations, dynamic clusters and metarooms
* Minor bugfix in naming of saved data
* Added ftp upload action server to the launch file
* Ftp upload task client
* respawn set to true
* Minor bugfix related to deleting of metric map saved data
* Added function to move old data to a cache folder instead of deleting it
* Added a launch file parameter for saving to the database and fixed a bug.
* Logging intermediate point clouds to the database. Logging dynamic clusters to the database
* task registration on demand option
* Update README.md
* Added functionality to check how many instances of an observation have been saved, and remove some of them if there are too many
* Added a launch file for the entire local metric map system
* Added ros-hydro-qt-build as a dependency in package.xml and updated the readme.
* Updated the readme
* Added readme file for the semantic_map package
* Added functionality to remove previously saved metric map data, which can be set via the launch parameter cleanup (yes/no). The default behavior atm is to delete previously saved data, i.e. all metarooms will be created from scratch. This does not affect the creation of individual room observations
* Downsampling of observation point cloud using a 2cm voxel grid instead of 0.5 cm
* Metric map task client
* Added launch file parameters for configuring the saving of intermediate data (would be used fro debugging purposes)
* launch files
* Local metric map nodes: cloud_merge - processing depth & rgb frames / point clouds and merging them into room observations; cloud_register - utilities for ICP and NDT point cloud registration; semantic_map - creating and managing the local metric map, updating the map with new room observations, extracting dynamic clusters, maintaining the XML structure on the disk.
* Contributors: Bob, Johan Ekekrantz, Linda's sidekick, Nick Hawes, Nils Bore, Rares Ambrus, RaresAmbrus, cburbridge, cvapdemo, mailto:thomas.faeulhammer@tuwien.ac.at
```
