### PR TITLE
strands_systems: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8098,10 +8098,18 @@ repositories:
       version: hydro-devel
     status: developed
   strands_systems:
+    release:
+      packages:
+      - strands_bringup
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_systems.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/strands-project/strands_systems.git
       version: hydro-devel
+    status: developed
   strands_ui:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_systems` to `0.0.1-0`:
- upstream repository: https://github.com/strands-project/strands_systems.git
- release repository: https://github.com/strands-project-releases/strands_systems.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## strands_bringup

```
* removing head user
* Update README.md
* Create README.md
* bug fixes
* Creating strands_bringup removing strands_bob, strands_linda, strands_rosie, strands_uol_sim and strands_wernee
* Contributors: Jaime Pulido Fentanes
```
