### PR TITLE
scitos_drivers: 0.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7393,12 +7393,13 @@ repositories:
     release:
       packages:
       - flir_pantilt_d46
+      - scitos_bringup
       - scitos_drivers
       - scitos_mira
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_drivers.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_drivers` to `0.0.7-0`:
- upstream repository: https://github.com/strands-project/scitos_drivers.git
- release repository: https://github.com/strands-project-releases/scitos_drivers.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.6-0`
## scitos_bringup

```
* changed version number
* cleaning undesired files
* preparing to move
* Contributors: Jaime Pulido Fentanes, Marc Hanheide
```
