### PR TITLE
strands_executive: 0.0.8-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7965,12 +7965,14 @@ repositories:
       packages:
       - scheduler
       - scipoptsuite
+      - sim_clock
       - strands_executive_msgs
       - task_executor
+      - wait_action
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.8-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.7-0`
## scheduler
- No changes
## scipoptsuite
- No changes
## sim_clock

```
* Updated install targets.
* Copied in sim_clock and wait_node without history
* Contributors: Nick Hawes
* Copied in sim_clock and wait_node without history
* Contributors: Nick Hawes
```
## strands_executive_msgs
- No changes
## task_executor

```
* Fixing up bugs in routine
* Added wait node back in.
* Updating task routine to be more flexible wrt window start and end times.
* Updated scheduled task executor with distance matrix parts and removed MDP depdendencies in sm base executor which I had previous forgotten.
* Contributors: Nick Hawes
```
## wait_action

```
* Updated install targets.
* Copied in sim_clock and wait_node without history
* Contributors: Nick Hawes
```
