### PR TITLE
strands_executive: 0.0.9-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7972,7 +7972,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.8-0
+      version: 0.0.9-1
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.9-1`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.8-0`
## scheduler
- No changes
## scipoptsuite
- No changes
## sim_clock

```
* Corrected setup.py
* Contributors: Nick Hawes
```
## strands_executive_msgs
- No changes
## task_executor
- No changes
## wait_action

```
* Corrected setup.py
* Contributors: Nick Hawes
```
