### PR TITLE
strands_executive_behaviours: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7978,6 +7978,19 @@ repositories:
       url: https://github.com/strands-project/strands_executive.git
       version: hydro-release
     status: developed
+  strands_executive_behaviours:
+    release:
+      packages:
+      - routine_behaviours
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_executive_behaviours.git
+      version: 0.0.3-0
+    source:
+      type: git
+      url: https://github.com/strands-project/strands_executive_behaviours.git
+      version: hydro-devel
+    status: developed
   strands_hri:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive_behaviours` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/strands_executive_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_executive_behaviours.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## routine_behaviours

```
* Corrected rosdep.
* Contributors: Nick Hawes
```
