### PR TITLE
data_compression: 0.0.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1245,6 +1245,15 @@ repositories:
       url: https://github.com/GertKanter/cyton_gamma_1500_description.git
       version: master
   data_compression:
+    release:
+      packages:
+      - catkinized_libav
+      - libav_image_transport
+      - rosbag_openni_compression
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/data_compression.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/strands-project/data_compression.git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_compression` to `0.0.1-0`:
- upstream repository: https://github.com/strands-project/data_compression.git
- release repository: https://github.com/strands-project-releases/data_compression.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `null`
## catkinized_libav

```
* Merge commit 'e3b1bba6165b7e6e75b9ae3b4c58ffb9a94324e0' as 'catkinized_libav/libav_trunk'
* Removed libav submodule
* Corrected maintainer's in packages
* Disabled x264 support in libav since it can mess up compilation and we don't need it for depth image transfer
* Cleaned up the catkinized_libav cmake file a bit
* Added install targets for catkinized_libav
* Trying to add the install targets correctly, still need to copy the symlinks
* Changed the cmake to work with submodules instead of cloning
* Change the branch of libav to 9.8
* Added libav as a submodule
* Added the necessary build depends in package.xml
* Added the catkinized libav package
* Contributors: Nils Bore
```
## libav_image_transport

```
* Update package.xml
* Corrected maintainer's in packages
* Added install targets for catkinized_libav
* Moved the README into correct package
* Now just using the original headers because why not
* Added the frame_id in the message of the encoded frame Package msg so we can use multiple cameras
* Removed padding to the right of the image and hacked the depth frame in the header for now, everything working
* Got the depth_registered cloud running at least
* Changed the dynamic config files to have depth image compression with ffv1 as default
* Removed the libav cmake module as it's not needed with the catkinized version
* Made the package depend on catkinized_libav instead of the normal library
* add missing dependency
* fix pixel formats
* add dynamic reconfigure server on subscriber side
* fix cmake include
* fix pts implementation
* add compile flag
* fix error with key_frame flag
* fix errors occurring in destructors
* change dependency classification
* fix timestamp implementation
* fix bug with packet
* leave the seach paths to cmake
* change dependency
* fix bug with backport
* fix problem with new version format of libav
* add install directives
* Update libav_plugins.xml
* initial commit
* Contributors: Dominique Hunziker, Marc Hanheide, Nils Bore, dominiquehunziker
```
## rosbag_openni_compression

```
* Corrected maintainer's in packages
* Added openni_wrapper as a run depend since the playback depends on that
* Put the rosbag_openni_compression into its own folder
* Contributors: Nils Bore
```
