### PR TITLE
strands_executive_behaviours: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7994,7 +7994,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive_behaviours.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive_behaviours.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive_behaviours` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/strands_executive_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_executive_behaviours.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.4-0`
## routine_behaviours

```
* Corrected day start and end
* Updated routinge to use new routine constraints.
* Cleaning up output and changing defaults for testing,
* Contributors: Nick Hawes
```
