### PR TITLE
scitos_drivers: 0.0.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -7425,7 +7425,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_drivers.git
-      version: 0.0.10-0
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_drivers` to `0.0.11-0`:
- upstream repository: https://github.com/strands-project/scitos_drivers.git
- release repository: https://github.com/strands-project-releases/scitos_drivers.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.10-0`
## flir_pantilt_d46
- No changes
## scitos_bringup

```
* removing unnecessary dependencies
* fixing dependencies
* Contributors: Jaime Pulido Fentanes
```
## scitos_drivers

```
* fixing dependencies 2
* Contributors: Jaime Pulido Fentanes
```
## scitos_mira
- No changes
