### PR TITLE
data_compression: 0.0.3-1 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -1254,7 +1254,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/data_compression.git
-      version: 0.0.3-0
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/strands-project/data_compression.git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_compression` to `0.0.3-1`:
- upstream repository: https://github.com/strands-project/data_compression.git
- release repository: https://github.com/strands-project-releases/data_compression.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-0`
## catkinized_libav
- No changes
## libav_image_transport
- No changes
## mongodb_openni_compression

```
* Covered all the cases with the action server and changed the names of the recorded topics to include the camera name
* Contributors: Nils Bore
```
## rosbag_openni_compression
- No changes
