### PR TITLE
scitos_drivers: 0.0.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5666,19 +5666,18 @@ repositories:
   scitos_drivers:
     release:
       packages:
-        - flir_pantilt_d46
-        - scitos_bringup
-        - scitos_drivers
-        - scitos_mira
+      - flir_pantilt_d46
+      - scitos_bringup
+      - scitos_drivers
+      - scitos_mira
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_drivers.git
-      version: 0.0.12-0
+      version: 0.0.14-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_drivers.git
       version: indigo-release
-      status: developed
   sentis_tof_m100:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_drivers` to `0.0.14-0`:
- upstream repository: https://github.com/strands-project/scitos_drivers.git
- release repository: https://github.com/strands-project-releases/scitos_drivers.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.12-0`
