### PR TITLE
mongodb_store: 0.1.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2927,7 +2927,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.6-0
+      version: 0.1.10-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.10-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.15`
- previous version for package: `0.1.6-0`
## mongodb_log
- No changes
## mongodb_store

```
* Replication now has db configurable.
  This fixes #54 <https://github.com/strands-project/mongodb_store/issues/54>.
* Added queue_size for indigo
* Contributors: Nick Hawes
```
## mongodb_store_msgs

```
* Replication now has db configurable.
  This fixes #54 <https://github.com/strands-project/mongodb_store/issues/54>.
* Contributors: Nick Hawes
```
