### PR TITLE
scitos_drivers: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5884,14 +5884,16 @@ repositories:
       - scitos_bringup
       - scitos_drivers
       - scitos_mira
+      - scitos_pc_monitor
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_drivers.git
-      version: 0.0.16-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_drivers.git
       version: indigo-release
+    status: developed
   sentis_tof_m100:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_drivers` to `0.1.1-0`:
- upstream repository: https://github.com/strands-project/scitos_drivers.git
- release repository: https://github.com/strands-project-releases/scitos_drivers.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.16-0`
## scitos_pc_monitor

```
* scitos_pc_monitor package
* Prepare pc_monitor for move to scitos_drivers
* Contributors: Chris Burbridge
```
