### PR TITLE
strands_navigation: 0.0.23-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6355,6 +6355,7 @@ repositories:
       - message_store_map_switcher
       - monitored_navigation
       - nav_goals_generator
+      - pose_initialiser
       - strands_navigation
       - strands_navigation_msgs
       - topological_navigation
@@ -6362,7 +6363,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.8-0
+      version: 0.0.23-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.23-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.8-0`
## joy_map_saver
- No changes
## message_store_map_switcher
- No changes
## monitored_navigation

```
* publishers now created with an explicit queue_size (indigo doesnt like it otherwise)
* Contributors: Bruno Lacerda
```
## nav_goals_generator
- No changes
## pose_initialiser
- No changes
## strands_navigation
- No changes
## strands_navigation_msgs
- No changes
## topological_navigation
- No changes
## topological_utils
- No changes
