### PR TITLE
strands_movebase: 0.0.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6342,7 +6342,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_movebase.git
-      version: 0.0.6-0
+      version: 0.0.14-0
     source:
       type: git
       url: https://github.com/strands-project/strands_movebase.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_movebase` to `0.0.14-0`:
- upstream repository: https://github.com/strands-project/strands_movebase.git
- release repository: https://github.com/strands-project-releases/strands_movebase.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.6-0`
## calibrate_chest

```
* Update README.md
* Added timeout if no point cloud received
* Made desired angle configurable
* Changed all the camera names to be parameters
* Polishing
* Added the publish option to the action server as well
* Made it a bit nicer
* Got it compiling
* Added dep also in package.xml
* Initial commit for making camera calibration an action server instead
* Contributors: Nils Bore
```
## strands_description
- No changes
## strands_movebase

```
* getting move base's own costmap clearance to clear the obstacle layer
* reverting resolution as it is too much for the current depth cloud config and it creates a lot of lingering obstacles
* new nav params
* defaul user needs to be ""
* Fixed indentation
* Added remove_edges_laser to install targets
* Made the calculation of the new points exact
* Changed default arguments to make clear that they are floats
* Added the new node in the launch file and included the decreased FOV obstacle adding laser in the sensor sources
* Now it should work
* Added a node that remove the edges of the laser
* Contributors: Bruno Lacerda, Nils Bore
```
