### PR TITLE
strands_recovery_behaviours: 0.0.10-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6402,7 +6402,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_recovery_behaviours.git
-      version: 0.0.10-1
+      version: 0.0.10-2
     source:
       type: git
       url: https://github.com/strands-project/strands_recovery_behaviours.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_recovery_behaviours` to `0.0.10-2`:
- upstream repository: https://github.com/strands-project/strands_recovery_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_recovery_behaviours.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.10-1`
## backoff_behaviour
- No changes
## backtrack_behaviour

```
* Added a try catch to reconfiguring move_base parameters
* Contributors: Nils Bore
```
## strands_human_help

```
* Changing help speech to explicitely tell people to look to the robot's screen
* bug fixes for twitter help
* adding twitter help - always for magnetic strip, once when nav or bumper fails 20 times in a row
* Contributors: Bruno Lacerda
```
## strands_monitored_nav_states

```
* Making sure free run is turned off after help is done
* adding simple "pause and the rety nav" recovery state
* removing clear costmaps recovery as move base seems to not be robust in terms of costmap reloading
* increase default of max bumper recoveries to very large number. it will be removed later because it doesnt make sense
* robot speaks to warn he is going to backtrack
* Contributors: Bruno Lacerda
```
## strands_recovery_behaviours

```
* adding twitter help - always for magnetic strip, once when nav or bumper fails 20 times in a row
* Contributors: Bruno Lacerda
```
