### PR TITLE
strands_webtools: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6446,7 +6446,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_webtools.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/strands-project/strands_webtools.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_webtools` to `0.0.2-0`:
- upstream repository: https://github.com/strands-project/strands_webtools.git
- release repository: https://github.com/strands-project-releases/strands_webtools.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.1-0`
## strands_webtools

```
* merged #62 <https://github.com/strands-project/strands_webtools/issues/62>
* Merge pull request #60 <https://github.com/strands-project/strands_webtools/issues/60> from cdondrup/hydro-devel
  strands_pedestrian_tracking has been renamed to mdl_people_tracker
* strands_pedestrian_tracking has been renamed to mdl_people_tracker
* Contributors: Christian Dondrup, Marc Hanheide
```
