### PR TITLE
scitos_2d_navigation: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5837,7 +5837,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_2d_navigation.git
-      version: 0.0.4-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_2d_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_2d_navigation` to `0.0.6-0`:
- upstream repository: https://github.com/strands-project/scitos_2d_navigation.git
- release repository: https://github.com/strands-project-releases/scitos_2d_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.4-0`
## scitos_2d_navigation

```
* Merge pull request #53 <https://github.com/strands-project/scitos_2d_navigation/issues/53> from bfalacerda/hydro-devel
  same params as the new strands_movebase. merging
* mirroring strands movebase params where possible
* new nav params
* Merge pull request #52 <https://github.com/strands-project/scitos_2d_navigation/issues/52> from BFALacerda/hydro-devel
  getting config of common costmap params to mirror strands_movebase
* removing params that arent used
* getting config of common costmap params to mirror strands_movebase
* Contributors: BFALacerda, Bruno Lacerda, bfalacerda
```
