### PR TITLE
strands_executive: 0.0.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6322,12 +6322,14 @@ repositories:
       packages:
       - scheduler
       - scipoptsuite
+      - sim_clock
       - strands_executive_msgs
       - task_executor
+      - wait_action
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.6-0
+      version: 0.0.16-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.16-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.6-0`
## scheduler
- No changes
## scipoptsuite
- No changes
## sim_clock
- No changes
## strands_executive_msgs
- No changes
## task_executor

```
* increasing timeout for nav
* Edited task allowed function to check task details.
* More none checking changes.
* Use is None instead of not.
  There's a reason it has been invented. This (and my next PR) probably fix the "local timezone doesn't work anymore" thing.
* Contributors: Bruno Lacerda, Lucas Beyer, Nick Hawes
```
## wait_action
- No changes
