### PR TITLE
strands_apps: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6300,6 +6300,7 @@ repositories:
     release:
       packages:
       - door_pass
+      - marathon_reporter
       - odometry_mileage
       - pose_extractor
       - ramp_climb
@@ -6307,11 +6308,12 @@ repositories:
       - roslaunch_axserver
       - state_checker
       - strands_apps
+      - strands_emails
       - topic_republisher
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_apps.git
-      version: 0.0.8-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/strands-project/strands_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.1.2-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.8-0`
## door_pass
- No changes
## marathon_reporter
- No changes
## odometry_mileage
- No changes
## pose_extractor
- No changes
## ramp_climb
- No changes
## reconfigure_inflation
- No changes
## roslaunch_axserver
- No changes
## state_checker
- No changes
## strands_apps
- No changes
## strands_emails

```
* fixing dir name
* Contributors: Jaime Pulido Fentanes
```
## topic_republisher
- No changes
