### PR TITLE
strands_hri: 0.0.7-3 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6351,7 +6351,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_hri.git
-      version: 0.0.7-2
+      version: 0.0.7-3
     source:
       type: git
       url: https://github.com/strands-project/strands_hri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_hri` to `0.0.7-3`:
- upstream repository: https://github.com/strands-project/strands_hri.git
- release repository: https://github.com/strands-project-releases/strands_hri.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.7-2`
## strands_gazing
- No changes
## strands_hri
- No changes
## strands_hri_launch
- No changes
## strands_human_aware_navigation

```
* [human_aware_navigation] Reading default velocities from move_base params on start
  Also not reconfiguring the min values any more. Those are never used but overwrite the set parameters.
* Contributors: Christian Dondrup
```
## strands_human_following
- No changes
## strands_interaction_behaviours
- No changes
## strands_simple_follow_me
- No changes
## strands_visualise_speech
- No changes
