### PR TITLE
strands_executive_behaviours: 0.0.12-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6344,7 +6344,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive_behaviours.git
-      version: 0.0.12-1
+      version: 0.0.12-2
     source:
       type: git
       url: https://github.com/strands-project/strands_executive_behaviours.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive_behaviours` to `0.0.12-2`:
- upstream repository: https://github.com/strands-project/strands_executive_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_executive_behaviours.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.12-1`
## routine_behaviours

```
* Added simple follow task in case we want to try it later.
* Updated code to allow tasks at ChargingPoint when battery is low.
* Checking for is not None explicitly. Sorry @lucab-eyer.
* Merge pull request #12 <https://github.com/strands-project/strands_executive_behaviours/issues/12> from hawesie/hydro-devel
  Added rechecking for docking during the night.
* Use is None instead of not.
  Same as strands-project/strands_executive#116 <https://github.com/strands-project/strands_executive/issues/116>
* Added rechecking for docking during the night.
* Contributors: Lucas Beyer, Nick Hawes
```
