### PR TITLE
openni_wrapper: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4213,6 +4213,12 @@ repositories:
       type: git
       url: https://github.com/ros-drivers/openni_launch.git
       version: indigo-devel
+  openni_wrapper:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/openni_wrapper.git
+      version: 0.0.7-0
   openrtm_aist:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_wrapper` to `0.0.7-0`:
- upstream repository: https://github.com/strands-project/openni_wrapper.git
- release repository: https://github.com/strands-project-releases/openni_wrapper.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
