### PR TITLE
CMP2020M: 0.0.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -6,6 +6,19 @@ release_platforms:
   ubuntu:
   - precise
 repositories:
+  CMP2020M:
+    release:
+      packages:
+      - catkinized_downward
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/CMP2020M.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/LCAS/CMP2020M.git
+      version: indigo-devel
+    status: maintained
   aau_multi_robot:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `CMP2020M` to `0.0.2-0`:
- upstream repository: https://github.com/LCAS/CMP2020M.git
- release repository: https://github.com/strands-project-releases/CMP2020M.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## catkinized_downward

```
* correct move
* Contributors: Marc Hanheide
```
