### PR TITLE
CMP2020M: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -13,7 +13,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/CMP2020M.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/LCAS/CMP2020M.git


### PR DESCRIPTION
Increasing version of package(s) in repository `CMP2020M` to `0.0.3-0`:
- upstream repository: https://github.com/LCAS/CMP2020M.git
- release repository: https://github.com/strands-project-releases/CMP2020M.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.2-0`
## catkinized_downward

```
* reverted to earlier version that SHOULD compile on hydro
* Contributors: Marc Hanheide
```
