### PR TITLE
strands_morse: 0.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6724,6 +6724,12 @@ repositories:
       url: https://github.com/strands-project/strands_hri.git
       version: hydro-devel
     status: developed
+  strands_morse:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_morse.git
+      version: 0.0.10-0
   strands_movebase:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.0.10-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## strands_morse

```
* Update opencv dependency for indigo.
* indigo-0.0.9
* Update changelog.
* Set run_depend for 14.04 STRANDS MORSE.
* Set path for 14.04 package installed MORSE.
* Switch to system python3.
* Contributors: Chris Burbridge
```
