### PR TITLE
lcas_teaching: 0.1.1-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3534,10 +3534,20 @@ repositories:
       version: 0.1.3-1
     status: maintained
   lcas_teaching:
+    release:
+      packages:
+      - catkinized_downward
+      - uol_morse_simulator
+      - uol_turtlebot_common
+      tags:
+        release: release/hydro/{package}/{version}
+      url: https://github.com/strands-project-releases/lcas_teaching.git
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/LCAS/teaching.git
       version: hydro-devel
+    status: developed
   leap_motion:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `lcas_teaching` to `0.1.1-0`:
- upstream repository: https://github.com/LCAS/teaching.git
- release repository: https://github.com/strands-project-releases/lcas_teaching.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## catkinized_downward

```
* bumped version after moving packages
* imported hydri-version
* imported planners
* Contributors: Marc Hanheide
```
## uol_morse_simulator

```
* bumped version after moving packages
* initialised with basic packages
* Contributors: Marc Hanheide
```
## uol_turtlebot_common

```
* bumped version after moving packages
* initialised with basic packages
* Contributors: Marc Hanheide
```
