### PR TITLE
lcas_teaching: 0.1.2-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3542,7 +3542,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/lcas_teaching.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/LCAS/teaching.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lcas_teaching` to `0.1.2-0`:
- upstream repository: https://github.com/LCAS/teaching.git
- release repository: https://github.com/strands-project-releases/lcas_teaching.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.1-0`
## catkinized_downward

```
* use tarball instead of fast-downward.org to download
* added tarball for planner
* Contributors: Marc Hanheide
```
## uol_morse_simulator
- No changes
## uol_turtlebot_common
- No changes
