### PR TITLE
strands_systems: 0.0.7-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8472,7 +8472,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_systems.git
-      version: 0.0.6-2
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/strands-project/strands_systems.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_systems` to `0.0.7-0`:
- upstream repository: https://github.com/strands-project/strands_systems.git
- release repository: https://github.com/strands-project-releases/strands_systems.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `0.0.6-2`
## strands_bringup

```
* Include pc_monitor in robot bringup.
  Includes the now released pc_monitor in the strands_robot launch file.
* removing config for monitored nav (its already a default and it looks like it doesnt work)
* Contributors: Bruno Lacerda, Chris Burbridge
```
