### PR TITLE
strands_systems: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6853,6 +6853,14 @@ repositories:
       url: https://github.com/strands-project/strands_social.git
       version: hydro-devel
     status: developed
+  strands_systems:
+    release:
+      packages:
+      - strands_bringup
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_systems.git
+      version: 0.0.8-0
   strands_ui:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_systems` to `0.0.8-0`:
- upstream repository: https://github.com/strands-project/strands_systems.git
- release repository: https://github.com/strands-project-releases/strands_systems.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.14`
- previous version for package: `null`
