### PR TITLE
openni_wrapper: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4319,7 +4319,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/openni_wrapper.git
-      version: 0.0.7-0
+      version: 0.0.8-0
   openrtm_aist:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_wrapper` to `0.0.8-0`:
- upstream repository: https://github.com/strands-project/openni_wrapper.git
- release repository: https://github.com/strands-project-releases/openni_wrapper.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.7-0`
## openni_wrapper

```
* indigo0.0.7
* Contributors: Chris Burbridge
```
