### PR TITLE
scitos_drivers: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6330,7 +6330,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_drivers.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_drivers` to `0.1.2-0`:
- upstream repository: https://github.com/strands-project/scitos_drivers.git
- release repository: https://github.com/strands-project-releases/scitos_drivers.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.1.1-0`
## flir_pantilt_d46

```
* Fix publisher queue_size for indigo.
* indigo-0.1.1
* Manual indigo version bump.
* Contributors: Chris Burbridge
```
## scitos_bringup

```
* Fix openni wrapper include.
  Renamed default camera to head_xtion, since the non-strands scitos by default has a head camera not a chest camera attached to the main machine. Removed obsolete publish_tf argument.
* Update for renamed pc_monitor.
* indigo-0.1.1
* Manual indigo version bump.
* Contributors: Chris Burbridge
```
## scitos_drivers

```
* indigo-0.1.1
* Manual indigo version bump.
* Add scitos_pc_monitor to metapackage.
* Contributors: Chris Burbridge
```
## scitos_mira

```
* indigo-0.1.1
* Manual indigo version bump.
* Contributors: Chris Burbridge
```
## scitos_pc_monitor

```
* Fix publisher queue_size for indigo.
* indigo-0.1.1
* Update changelogs.
* Manual indigo version bump.
* Prepare pc_monitor for move to scitos_drivers
* Contributors: Chris Burbridge
```
