### PR TITLE
lcas_teaching: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3040,6 +3040,17 @@ repositories:
       version: indigo-devel
     status: maintained
   lcas_teaching:
+    release:
+      packages:
+      - catkinized_downward
+      - uol_cmp3641m
+      - uol_kobuki_gazebo_plugins
+      - uol_morse_simulator
+      - uol_turtlebot_simulator
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/lcas_teaching.git
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/LCAS/teaching.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lcas_teaching` to `0.1.4-0`:
- upstream repository: https://github.com/LCAS/teaching.git
- release repository: https://github.com/strands-project-releases/lcas_teaching.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## catkinized_downward
- No changes
## uol_cmp3641m

```
* Remote uol_turtlebot_common package. Removed dependencies from uol_morse_simulator package that do not exist in hydro yet.
* Contributors: Christian Dondrup
```
## uol_kobuki_gazebo_plugins

```
* Adding the possibility of teleoperating the turtlebots via key op, see tutorial.md. Changing topic names to have the command velocities published under . Using the yocs_command_velocity_smoother as suggested by kobuki.
* Contributors: Christian Dondrup
```
## uol_morse_simulator

```
* Remote uol_turtlebot_common package. Removed dependencies from uol_morse_simulator package that do not exist in hydro yet.
* Contributors: Christian Dondrup
```
## uol_turtlebot_simulator

```
* Updated tutorial for indigo.
* Adding the possibility of teleoperating the turtlebots via key op, see tutorial.md. Changing topic names to have the command velocities published under . Using the yocs_command_velocity_smoother as suggested by kobuki.
* Contributors: Christian Dondrup
```
