### PR TITLE
metapackages: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3450,10 +3450,20 @@ repositories:
       version: groovy-devel
     status: maintained
   metapackages:
+    release:
+      packages:
+      - strands_base
+      - strands_desktop
+      - strands_robot
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/metapackages.git
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/strands-project/metapackages.git
       version: indigo-devel
+    status: developed
   metaruby:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `0.0.9-0`:
- upstream repository: https://github.com/strands-project/metapackages.git
- release repository: https://github.com/strands-project-releases/metapackages.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `null`
## strands_base
- No changes
## strands_desktop

```
* Fix morse run_depend.
* Contributors: Chris Burbridge
```
## strands_robot

```
* Merge branch 'hydro-devel' into indigo-devel
* disabled mira as not releaased for indigo yet
* Contributors: Marc Hanheide
```
