### PR TITLE
Revert "unidiff supports encoding as of 0.5.1, using it's new API"

### DIFF
--- a/test/test_url_validity.py
+++ b/test/test_url_validity.py
@@ -56,11 +56,10 @@ def detect_lines(diffstr):
     """Take a diff string and return a dict of
     files with line numbers changed"""
     resultant_lines = {}
-    # diffstr is already utf-8 encoded
-    io = StringIO(diffstr)
     # Force utf-8 re: https://github.com/ros/rosdistro/issues/6637
     encoding = 'utf-8'
-    udiff = unidiff.PatchSet(io, encoding)
+    io = StringIO(unicode(diffstr, encoding))
+    udiff = unidiff.PatchSet(io)
     for file in udiff:
         target_lines = []
         # if file.path in TARGET_FILES:


### PR DESCRIPTION
This reverts commit a3460b141d2bdc08d73ba23ae73bb00a5b9c72c0.
