### PR TITLE
strands_qsr_lib: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7364,10 +7364,11 @@ repositories:
     release:
       packages:
       - qsr_lib
+      - strands_qsr_lib
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_qsr_lib.git
-      version: 0.0.1-0
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/strands-project/strands_qsr_lib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_qsr_lib` to `0.0.2-0`:
- upstream repository: https://github.com/strands-project/strands_qsr_lib.git
- release repository: https://github.com/strands-project-releases/strands_qsr_lib.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.1-0`
## qsr_lib
- No changes
## strands_qsr_lib

```
* Created changelog
* Adding meta package for future extension.
  Meta package will be added to strands-desktop and strands-robot for convenience.
* Contributors: Christian Dondrup
* Adding meta package for future extension.
  Meta package will be added to strands-desktop and strands-robot for convenience.
* Contributors: Christian Dondrup
```
