### PR TITLE
metapackages: 0.0.10-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -3897,11 +3897,12 @@ repositories:
       packages:
       - strands_base
       - strands_desktop
+      - strands_extras
       - strands_robot
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/metapackages.git
-      version: 0.0.8-0
+      version: 0.0.10-0
     source:
       type: git
       url: https://github.com/strands-project/metapackages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `0.0.10-0`:
- upstream repository: https://github.com/strands-project/metapackages.git
- release repository: https://github.com/strands-project-releases/metapackages.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.8-0`
## strands_base
- No changes
## strands_desktop

```
* Revert "Fix morse run_depend." as it's not valid for hydro"
  This reverts commit 07af84abc91d079dfc7ee8c14ad71e36ec01879f.
* Adding a strands_extras metapackage
  Currently this only contains strands_qsr_lib but since this did not feel like being part of a base system, I created this extras package which might become more populated and some of the packages from base could maybe moved here as well.
* Adding a strands_extras metapackage
  Currently this only contains strands_qsr_lib but since this did not feel like being part of a base system, I created this extras package which might become more populated and some of the packages from base could maybe moved here as well.
* Contributors: Christian Dondrup, Marc Hanheide
```
## strands_extras

```
* Adding a strands_extras metapackage
  Currently this only contains strands_qsr_lib but since this did not feel like being part of a base system, I created this extras package which might become more populated and some of the packages from base could maybe moved here as well.
* Adding a strands_extras metapackage
  Currently this only contains strands_qsr_lib but since this did not feel like being part of a base system, I created this extras package which might become more populated and some of the packages from base could maybe moved here as well.
* Contributors: Christian Dondrup
* Adding a strands_extras metapackage
  Currently this only contains strands_qsr_lib but since this did not feel like being part of a base system, I created this extras package which might become more populated and some of the packages from base could maybe moved here as well.
* Adding a strands_extras metapackage
  Currently this only contains strands_qsr_lib but since this did not feel like being part of a base system, I created this extras package which might become more populated and some of the packages from base could maybe moved here as well.
* Contributors: Christian Dondrup
```
## strands_robot

```
* Adding a strands_extras metapackage
  Currently this only contains strands_qsr_lib but since this did not feel like being part of a base system, I created this extras package which might become more populated and some of the packages from base could maybe moved here as well.
* Adding a strands_extras metapackage
  Currently this only contains strands_qsr_lib but since this did not feel like being part of a base system, I created this extras package which might become more populated and some of the packages from base could maybe moved here as well.
* Contributors: Christian Dondrup
```
