### PR TITLE
metapackages: 0.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3461,11 +3461,12 @@ repositories:
       packages:
       - strands_base
       - strands_desktop
+      - strands_extras
       - strands_robot
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/metapackages.git
-      version: 0.0.9-0
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/strands-project/metapackages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `0.0.11-0`:
- upstream repository: https://github.com/strands-project/metapackages.git
- release repository: https://github.com/strands-project-releases/metapackages.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.16`
- previous version for package: `0.0.9-0`
