### PR TITLE
strands_morse: 0.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7694,7 +7694,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.0.10-0
+      version: 0.0.11-0
   strands_movebase:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.0.11-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.10-0`
## strands_morse

```
* Merge pull request #93 <https://github.com/strands-project/strands_morse/issues/93> from kunzel/indigo-devel
  set control type to "Position"
* set control type to "Position"
* indigo-0.0.10
* Update changelog.
* Update opencv dependency for indigo.
* indigo-0.0.9
* Update changelog.
* Set run_depend for 14.04 STRANDS MORSE.
* Set path for 14.04 package installed MORSE.
* Switch to system python3.
* Contributors: Chris Burbridge, Lars Kunze
```
