### PR TITLE
strands_movebase: 0.0.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7910,12 +7910,13 @@ repositories:
     release:
       packages:
       - calibrate_chest
+      - movebase_state_service
       - strands_description
       - strands_movebase
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_movebase.git
-      version: 0.0.14-0
+      version: 0.0.15-0
     source:
       type: git
       url: https://github.com/strands-project/strands_movebase.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_movebase` to `0.0.15-0`:
- upstream repository: https://github.com/strands-project/strands_movebase.git
- release repository: https://github.com/strands-project-releases/strands_movebase.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.14-0`
## movebase_state_service

```
* fixed version number
* Merge remote-tracking branch 'origin/state_snapshot' into state_snapshot
* Changed enum to be portable
* Removed pcl_ros dependency and added installed the node
* Update package.xml
* Changed the plan topics
* Removed old code
* Fixed some bugs
* Changed the default folder for storing the images
* Added the state snapshot service for saving the current costmaps with the paths overlaid
* Contributors: Marc Hanheide, Nils Bore, Rares Ambrus
```
