### PR TITLE
strands_movebase: 0.0.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7916,7 +7916,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_movebase.git
-      version: 0.0.15-0
+      version: 0.0.16-0
     source:
       type: git
       url: https://github.com/strands-project/strands_movebase.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_movebase` to `0.0.16-0`:
- upstream repository: https://github.com/strands-project/strands_movebase.git
- release repository: https://github.com/strands-project-releases/strands_movebase.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.15-0`
## calibrate_chest
- No changes
## movebase_state_service

```
* Merge pull request #38 <https://github.com/strands-project/strands_movebase/issues/38> from nilsbore/state_snapshot
  [movebase_state_service] Added navfn as dependency in movebase_state_service
* Forgot to add navfn as dependency in movebase_state_service
* Contributors: Nils Bore
```
## strands_description
- No changes
## strands_movebase
- No changes
