### PR TITLE
strands_ui: 0.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8085,12 +8085,13 @@ repositories:
     release:
       packages:
       - mary_tts
+      - pygame_managed_player
       - strands_ui
       - strands_webserver
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_ui.git
-      version: 0.0.11-0
+      version: 0.0.12-0
     source:
       type: git
       url: https://github.com/strands-project/strands_ui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_ui` to `0.0.12-0`:
- upstream repository: https://github.com/strands-project/strands_ui.git
- release repository: https://github.com/strands-project-releases/strands_ui.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.11-0`
## pygame_managed_player

```
* added python header
* removed launch file as it doesn't belong here.
* all the meta-data for the new package and its deps
* moved into new package
* moved files to new package
* Contributors: Marc Hanheide
```
