### PR TITLE
strands_ui: 0.0.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8085,13 +8085,14 @@ repositories:
     release:
       packages:
       - mary_tts
+      - music_player
       - pygame_managed_player
       - strands_ui
       - strands_webserver
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_ui.git
-      version: 0.0.12-0
+      version: 0.0.13-0
     source:
       type: git
       url: https://github.com/strands-project/strands_ui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_ui` to `0.0.13-0`:
- upstream repository: https://github.com/strands-project/strands_ui.git
- release repository: https://github.com/strands-project-releases/strands_ui.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.12-0`
## music_player

```
* correct version number
* Fixing install targets and renaming artifacts.
* Forgot to rename the folder in the src directory. Now this is also called music_player. Thank you @marc-hanheide
* Renamed to music_player
* Contributors: Christian Dondrup, Marc Hanheide
```
