### PR TITLE
strands_recovery_behaviours: 0.0.11-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8583,10 +8583,11 @@ repositories:
       - strands_human_help
       - strands_monitored_nav_states
       - strands_recovery_behaviours
+      - walking_group_recovery
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_recovery_behaviours.git
-      version: 0.0.10-1
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/strands-project/strands_recovery_behaviours.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_recovery_behaviours` to `0.0.11-0`:
- upstream repository: https://github.com/strands-project/strands_recovery_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_recovery_behaviours.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.10-1`
## walking_group_recovery

```
* Fixing version number
* Now stopping music when we are finished
* Created the walking group recovery with server to change back and forth between state machines
* Contributors: Christian Dondrup, Nils Bore
```
