### PR TITLE
strands_perception_people: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8019,7 +8019,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/strands-project/strands_perception_people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `0.1.1-0`:
- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.0-0`
## bayes_people_tracker
- No changes
## bayes_people_tracker_logging
- No changes
## detector_msg_to_pose_array
- No changes
## ground_plane_estimation
- No changes
## mdl_people_tracker
- No changes
## odometry_to_motion_matrix
- No changes
## opencv_warco

```
* Merge pull request #132 <https://github.com/strands-project/strands_perception_people/issues/132> from cdondrup/opencv_warco
  Refactoring opencv_warco to enable build from install and devel
* Refactoring opencv_warco to be able to build strands_head_orientation from install and devel.
* Contributors: Christian Dondrup
```
## perception_people_launch
- No changes
## strands_head_orientation

```
* Refactoring opencv_warco to be able to build strands_head_orientation from install and devel.
* Contributors: Christian Dondrup
```
## strands_perception_people

```
* Merge pull request #132 <https://github.com/strands-project/strands_perception_people/issues/132> from cdondrup/opencv_warco
  Refactoring opencv_warco to enable build from install and devel
* Adding opencv_warco and strands_head_orientation to metapackage.
* Contributors: Christian Dondrup
```
## upper_body_detector
- No changes
## visual_odometry
- No changes
