### PR TITLE
edge_leg_detector: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1528,6 +1528,17 @@ repositories:
       url: https://github.com/plasmodic/ecto_ros.git
       version: master
     status: maintained
+  edge_leg_detector:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/edge_leg_detector.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/strands-project/edge_leg_detector.git
+      version: master
+    status: maintained
   eigen_stl_containers:
     release:
       tags:


### PR DESCRIPTION
Increasing version of package(s) in repository `edge_leg_detector` to `0.0.2-0`:
- upstream repository: https://github.com/strands-project/edge_leg_detector.git
- release repository: https://github.com/strands-project-releases/edge_leg_detector.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## edge_leg_detector

```
* Add default laser scanner source node.
* Merge pull request #2 <https://github.com/strands-project/edge_leg_detector/issues/2> from ferdianjovan/master
  Fixing the time stamp problem
  CMake.txt+package.xml modified
* add install part in CMake.txt
* becomes edge
* Update package.xml
* Trying to change the entire package (from leg_detector to simple_leg_detector)
* modify cmake, package.xml and readme
* Merge branch 'master' of https://github.com/marcobecerrap/leg_detector
* change the distance to make it safer, replace time stamp with ROS::Time::Now()
* fixed time stamp
* Merge pull request #1 <https://github.com/strands-project/edge_leg_detector/issues/1> from ferdianjovan/master
  Added launch file, fixed bugs
* delete swp file
* add launch file, add delay
* Erased redundant leg patterns
* Unused variables deletion
* Added brief description and reference in README.md
* Added brief description and reference in README.md
* Uploading last stable version, first with PoseArray msg
* Contributors: Ferdian Jovan, KT, Marco Antonio Becerra Pedraza, Marco Becerra
```
