### PR TITLE
strands_perception_people: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8023,6 +8023,7 @@ repositories:
       - bayes_people_tracker_logging
       - detector_msg_to_pose_array
       - ground_plane_estimation
+      - human_trajectory
       - mdl_people_tracker
       - odometry_to_motion_matrix
       - opencv_warco
@@ -8034,7 +8035,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/strands-project/strands_perception_people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `0.1.2-0`:
- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.1-0`
## human_trajectory

```
* Fixing my sed mistakes and the install targets for human_trajectory.
* fixing Cmake and package.xml, add this package in metapackage
* add dependency in Cmake and package.xml
* add human_trajectory package to indigo-devel branch
* Contributors: Christian Dondrup, Ferdian Jovan
```
