### PR TITLE
data_compression: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1198,6 +1198,22 @@ repositories:
       type: git
       url: https://github.com/HumaRobotics/darwin_gazebo.git
       version: master
+  data_compression:
+    release:
+      packages:
+      - catkinized_libav
+      - libav_image_transport
+      - mongodb_openni_compression
+      - rosbag_openni_compression
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/data_compression.git
+      version: 0.0.9-0
+    source:
+      type: git
+      url: https://github.com/strands-project/data_compression.git
+      version: hydro-devel
+    status: developed
   demo_lidar:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_compression` to `0.0.9-0`:
- upstream repository: https://github.com/strands-project/data_compression.git
- release repository: https://github.com/strands-project-releases/data_compression.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.18`
- previous version for package: `null`
## catkinized_libav

```
* removed the external libraries to be expected
* Revert "added new rosdep key as dependency. See https://github.com/strands-project/rosdistro/pull/370"
  This reverts commit 411841657371e342cb03df879a4b5d247be43151.
* added new rosdep key as dependency. See https://github.com/strands-project/rosdistro/pull/370
* Contributors: Marc Hanheide
```
## libav_image_transport

```
* added catkinized_libav as dependency to make sure it's built prior to libav_image_transport
* Contributors: Marc Hanheide
```
## mongodb_openni_compression

```
* fixed the mongodb_play.py call
  The name of the RGB topic, under which it is stored in mongo, was wrong
* Contributors: Vojtech Novak
```
## rosbag_openni_compression
- No changes
