### PR TITLE
fremen: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1710,6 +1710,21 @@ repositories:
       url: https://github.com/ros-drivers/freenect_stack.git
       version: master
     status: maintained
+  fremen:
+    release:
+      packages:
+      - fremengrid
+      - frenap
+      - froctomap
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/fremen.git
+      version: 0.1.0-0
+    source:
+      type: git
+      url: https://github.com/strands-project/fremen.git
+      version: master
+    status: developed
   frontier_exploration:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `fremen` to `0.1.0-0`:
- upstream repository: https://github.com/strands-project/fremen.git
- release repository: https://github.com/strands-project-releases/fremen.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `null`
## fremengrid

```
* Packages improved.
* Contributors: Tom Krajnik
```
## frenap

```
* Actionlib generate messages
* Packages improved.
* Contributors: Tom Krajnik
```
## froctomap

```
* Packages improved.
* Contributors: Tom Krajnik
```
