### PR TITLE
strands_qsr_lib: 0.0.5-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8585,7 +8585,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/strands_qsr_lib.git
-      version: 0.0.3-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/strands_qsr_lib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_qsr_lib` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/strands_qsr_lib.git
- release repository: https://github.com/strands-project-releases/strands_qsr_lib.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.3-0`
## qsr_lib

```
* There was a tag with a higher version number. Adjusting numbers to release for necessary bug fixes in the ROS client.
* Contributors: Christian Dondrup
```
## strands_qsr_lib

```
* There was a tag with a higher version number. Adjusting numbers to release for necessary bug fixes in the ROS client.
* Contributors: Christian Dondrup
```
