### PR TITLE
twitter_bootstrap: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8677,7 +8677,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/twitter_bootstrap.git
-      version: 0.0.1-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/strands-project/twitter_bootstrap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twitter_bootstrap` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/twitter_bootstrap.git
- release repository: https://github.com/strands-project-releases/twitter_bootstrap.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.1-0`
