### PR TITLE
twitter_bootstrap: 0.0.3-0 in 'hydro/distribution.yaml' [bloom]

### DIFF
--- a/hydro/distribution.yaml
+++ b/hydro/distribution.yaml
@@ -8961,7 +8961,7 @@ repositories:
       tags:
         release: release/hydro/{package}/{version}
       url: https://github.com/strands-project-releases/twitter_bootstrap.git
-      version: 0.0.1-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/strands-project/twitter_bootstrap.git


### PR DESCRIPTION
Increasing version of package(s) in repository `twitter_bootstrap` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/twitter_bootstrap.git
- release repository: https://github.com/strands-project-releases/twitter_bootstrap.git
- distro file: `hydro/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.1-0`
