### PR TITLE
fremen: 0.1.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1734,12 +1734,13 @@ repositories:
     release:
       packages:
       - fremengrid
+      - fremenserver
       - frenap
       - froctomap
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/fremen.git
-      version: 0.1.0-0
+      version: 0.1.1-0
     source:
       type: git
       url: https://github.com/strands-project/fremen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fremen` to `0.1.1-0`:
- upstream repository: https://github.com/strands-project/fremen.git
- release repository: https://github.com/strands-project-releases/fremen.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.0-0`
## fremengrid
- No changes
## fremenserver

```
* Message generation now in CMakelist
* Dependency added
* Favours slower dynamics, entropy predictions.
* Readme test
* Readme test
* Readme test
* Server updated to provide more detailed feedback. Checking for redundant states added.
* Common FreMEn-based prediction module.
* Contributors: Tom Krajnik
```
## frenap
- No changes
## froctomap
- No changes
