### PR TITLE
strands_qsr_lib: 0.0.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8284,7 +8284,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_qsr_lib.git
-      version: 0.0.5-0
+      version: 0.0.6-0
     source:
       type: git
       url: https://github.com/strands-project/strands_qsr_lib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_qsr_lib` to `0.0.6-0`:
- upstream repository: https://github.com/strands-project/strands_qsr_lib.git
- release repository: https://github.com/strands-project-releases/strands_qsr_lib.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.5-0`
## qsr_lib

```
* Closes #23 <https://github.com/strands-project/strands_qsr_lib/issues/23>: removed annoying message: "Resetting QSRlib data"
* Removing the end operator
* Using rospy.log* for ROS node outputs. Prevents spamming the terminal bu setting most of it to debug level
* Contributors: Christian Dondrup, Yiannis
```
## strands_qsr_lib
- No changes
