### PR TITLE
robomongo_ros: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6084,7 +6084,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/robomongo_ros.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/strands-project/robomongo.git


### PR DESCRIPTION
Increasing version of package(s) in repository `robomongo_ros` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/robomongo.git
- release repository: https://github.com/strands-project-releases/robomongo_ros.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## robomongo

```
* Merge pull request #1 <https://github.com/strands-project/robomongo/issues/1> from nilsbore/master
  Changed default install location
* Merge remote-tracking branch 'strands/master'
* Changed default install location
* Contributors: Marc Hanheide, Nils Bore
```
