### PR TITLE
strands_perception_people: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8284,7 +8284,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/strands-project/strands_perception_people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `0.1.4-0`:
- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.3-0`
## bayes_people_tracker

```
* Publishin people_msgs/People and adding orientation.
* forgot to undo my config for detectors.yaml in bayes_people_tracker
* provide online stitching poses into trajectories
* add online trajectory construction from /people_tracker/positions
* Contributors: Christian Dondrup, Ferdian Jovan
```
## bayes_people_tracker_logging
- No changes
## detector_msg_to_pose_array
- No changes
## ground_plane_estimation
- No changes
## human_trajectory

```
* provide online stitching poses into trajectories
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_perception_people into indigo-devel
* add online trajectory construction from /people_tracker/positions
* Contributors: Ferdian Jovan
```
## mdl_people_tracker
- No changes
## odometry_to_motion_matrix
- No changes
## opencv_warco

```
* Added missing include and linking. These were necessary to compile under OS X.
* Contributors: Nick Hawes
```
## perception_people_launch
- No changes
## strands_head_orientation
- No changes
## strands_perception_people
- No changes
## upper_body_detector
- No changes
## visual_odometry
- No changes
