### PR TITLE
strands_ui: 0.0.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8413,7 +8413,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_ui.git
-      version: 0.0.14-0
+      version: 0.0.15-0
     source:
       type: git
       url: https://github.com/strands-project/strands_ui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_ui` to `0.0.15-0`:
- upstream repository: https://github.com/strands-project/strands_ui.git
- release repository: https://github.com/strands-project-releases/strands_ui.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.14-0`
## mary_tts
- No changes
## mongodb_media_server

```
* added mongodb_store as build_depend as it is needed for cmake step
* Contributors: Marc Hanheide
```
## music_player
- No changes
## pygame_managed_player

```
* removed redundant dep
* added rostest as dependencies
* Contributors: Marc Hanheide
```
## strands_ui
- No changes
## strands_webserver
- No changes
