### PR TITLE
strands_morse: 0.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8387,7 +8387,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.0.11-0
+      version: 0.0.12-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.0.12-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.11-0`
## strands_morse

```
* Merge pull request #104 <https://github.com/strands-project/strands_morse/issues/104> from Jailander/indigo-devel
  Adding door gaps in South wing
* Adding door gaps in South wing
* Merge pull request #103 <https://github.com/strands-project/strands_morse/issues/103> from Jailander/indigo-devel
  AAF simulations
* nicer simulation environment (needs features)
* adding aaf simulation
* Merge pull request #101 <https://github.com/strands-project/strands_morse/issues/101> from kunzel/indigo-devel
  start ptu action server by default; fix issue with ptu action server and...
* Merge pull request #102 <https://github.com/strands-project/strands_morse/issues/102> from mudrole1/indigo-devel
  G4S simulation environment
* g4s simulation extended by population area2 with furniture
* Blender models and scripts for g4s simulation. Only area1 is ready.
* fix issue #96 <https://github.com/strands-project/strands_morse/issues/96> (morse odom vs dwa planner)
* replace floor of environment with simple plane
* start ptu action server by default; fix issue with ptu action server and morse topic using a republisher
* Contributors: Jaime Pulido Fentanes, Lars Kunze, Lenka, Marc Hanheide
```
