### PR TITLE
strands_navigation: 0.0.24-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8424,7 +8424,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.23-0
+      version: 0.0.24-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.24-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.23-0`
## joy_map_saver
- No changes
## message_store_map_switcher
- No changes
## monitored_navigation

```
* adding launch and config dirs to install targets
* explicit queue size for pub
* Contributors: Bruno Lacerda
```
## nav_goals_generator
- No changes
## pose_initialiser
- No changes
## strands_navigation
- No changes
## strands_navigation_msgs

```
* adding sensor_msgs to package.xml
* adding costmaps to the monitored nav event logging
* Contributors: Bruno Lacerda
```
## topological_navigation
- No changes
## topological_utils

```
* Fix in map to yaml
* Added a boolean value indicating whether the returned nodes are actual nodes in the topological map
* Clean up
* Print message
* Clean up
* returning nodes based on the mongodb node metadata
* Adding scripts for new file format
* Added map name to the service message
* Returning random data
* Adding topological node metadata query service - initial commit
* Added better handling of time for dummy navigation.
* Add list maps utility.
* Contributors: Chris Burbridge, Jailander, Nick Hawes, Rares Ambrus
```
