### PR TITLE
openni_wrapper: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5098,7 +5098,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/openni_wrapper.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/strands-project/openni_wrapper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_wrapper` to `0.0.9-0`:
- upstream repository: https://github.com/strands-project/openni_wrapper.git
- release repository: https://github.com/strands-project-releases/openni_wrapper.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `0.0.8-0`
## openni_wrapper

```
* Merge pull request #18 <https://github.com/strands-project/openni_wrapper/issues/18> from RaresAmbrus/indigo-devel
  Added image_proc and depth_image_proc dependencies
* Added image_proc and depth_image_proc dependencies
* Merge pull request #16 <https://github.com/strands-project/openni_wrapper/issues/16> from hawesie/indigo-devel
  Removed incorrect return values.
* Removed incorrect return values.
* indigo-0.0.8
* Update changelog.
* indigo0.0.7
* Contributors: Chris Burbridge, Marc Hanheide, Nick Hawes, Rares
```
