### PR TITLE
scitos_apps: 0.0.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7841,7 +7841,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_apps.git
-      version: 0.0.14-0
+      version: 0.0.15-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_apps` to `0.0.15-0`:
- upstream repository: https://github.com/strands-project/scitos_apps.git
- release repository: https://github.com/strands-project-releases/scitos_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.14-0`
## scitos_apps
- No changes
## scitos_cmd_vel_mux
- No changes
## scitos_dashboard
- No changes
## scitos_docking

```
* Docking station position parametrized - allows to use maps with arbitrary docking station position. Circle detection sensitivity increased - allows to dock in adverse lighting conditions. Initial stages of docking do not check if the robot behaves as expected anymore (this was included to verify if other nodes still send commands to the robot or if the robot was moving when charging was initiated) - improves interaction with higher navigation layers that seemed to activate the charging while the robot was still moving.
* Contributors: Tom Krajnik
```
## scitos_ptu

```
* Action server metric map removed.
* renamed the action server
* Added a log topic for the ptu server
* new ptu server that logs to the database
* action server feedback message
* Added feedback in the ptu action server
* Action message with fields for various parameters
* Moving the action file to the root of the package
* updated the PTU action server to check that the desired position has been reacheed using the /ptu/state message
* package dependencies
* action server for ptu
* Contributors: Rares Ambrus, Tom Krajnik, default, rares
```
## scitos_teleop

```
* Added resetting the magnetic barrier motor stop to rumble_control
* Contributors: Christian Dondrup
```
## scitos_touch

```
* Fixing boost parse error
* Contributors: Nick Hawes
```
