### PR TITLE
strands_navigation: 0.0.25-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8424,7 +8424,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.24-0
+      version: 0.0.25-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.25-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.24-0`
## joy_map_saver
- No changes
## message_store_map_switcher
- No changes
## monitored_navigation
- No changes
## nav_goals_generator
- No changes
## pose_initialiser
- No changes
## strands_navigation
- No changes
## strands_navigation_msgs
- No changes
## topological_navigation

```
* Renamed to .py to be consistent.
* Contributors: Nick Hawes
```
## topological_utils

```
* Added the option to simulate time as an argument to the file.
* Renamed to .py to be consistent.
* Contributors: Nick Hawes
```
