### PR TITLE
strands_navigation: 0.0.27-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8439,7 +8439,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.26-0
+      version: 0.0.27-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.27-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.26-0`
## joy_map_saver
- No changes
## message_store_map_switcher
- No changes
## monitored_navigation

```
* Update README.md
* Update README.md
* Update README.md
* edit mon nav read me
* added services to get current human helpers and recoveries from mon nav
* adding message def to dynamically load python objects to the monitored_nav state machine
* Update README.md
* Update README.md
* Update README.md
* edit mon nav read me
* added services to get current human helpers and recoveries from mon nav
* adding message def to dynamically load python objects to the monitored_nav state machine
* Contributors: Bruno Lacerda
```
## nav_goals_generator
- No changes
## pose_initialiser
- No changes
## strands_navigation
- No changes
## strands_navigation_msgs

```
* Adding topological map editor launch file,
  replacing map_publisher with map manager,
  adding add_node service
* commiting migrate script plus typo fix
* redefining msgs to include localise by topic and inflation radius and simplifying recovery behaviours definition by setting them in one config string
* bug fixes
* Navigation and policy_executor working with new defs
* turning Message back to one single pose as agreed it will be sorted using the carrot planner
* added services to get current human helpers and recoveries from mon nav
* adding message def to dynamically load python objects to the monitored_nav state machine
* bug fixes
* committing map creation script
* Adding Recovery behaviours to edges full definition
* Adding recovery behaviours to edges
* Merge branch 'topological-testing' of https://github.com/strands-project/strands_navigation into topological-testing
* added services to get current human helpers and recoveries from mon nav
* adding message def to dynamically load python objects to the monitored_nav state machine
* adding Get Topological Map service
* adding changes to messages and creating topological testing branch locally
* removing traversabilty from edge message
* commiting latest versions of messages
* switching NavRoute to new def
* renaming new definitions to old message types
* new branch created
* Contributors: Bruno Lacerda, Jaime Pulido Fentanes
```
## topological_navigation

```
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_navigation into indigo-devel
  Conflicts:
  topological_navigation/CMakeLists.txt
* Adding topological map editor launch file,
  replacing map_publisher with map manager,
  adding add_node service
* adding edit mode to visualise
* fixing typo
* sending the robot to waypoint when in the influence area of the target node
* making sure robot executes action when reaching node in policy execution
* Navigation and policy_executor working with new defs
* bug fixes
* adding Get Topological Map service
* new branch created
* Contributors: Bruno Lacerda, Jaime Pulido Fentanes
```
## topological_utils

```
* sending the robot to waypoint when in the influence area of the target node
* removing pointset b testing
* commiting migrate script plus typo fix
* map to Json utilities
* fixing bug by which undocking edge was not being created
* bug fixes
* Now waypoint to yaml automatically Includes ChargingPoint
* tmap_to_yaml.py now includes default values for edges
* Navigation and policy_executor working with new defs
* New map format export and insertion scripts
* committing map creation script
* Adding recovery behaviours to edges
* new branch created
* Contributors: Jailander, Jaime Pulido Fentanes
```
