### PR TITLE
strands_morse: 0.0.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8456,7 +8456,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.0.14-0
+      version: 0.0.15-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.0.15-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.14-0`
## strands_morse

```
* Merge pull request #108 <https://github.com/strands-project/strands_morse/issues/108> from Jailander/master
  improvements to simulation
* improvements to simulation
* Contributors: Jaime Pulido Fentanes, Marc Hanheide
```
