### PR TITLE
strands_executive: 0.0.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8403,6 +8403,8 @@ repositories:
   strands_executive:
     release:
       packages:
+      - gcal_routine
+      - mdp_plan_exec
       - scheduler
       - scipoptsuite
       - sim_clock
@@ -8412,7 +8414,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.16-0
+      version: 0.0.17-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.17-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.16-0`
## gcal_routine

```
* bumped version number
* 

    * extended README (documented all parameters)
    * Made all parameters work

* added README
* param had wrong name
* made this work in reality
* added proper use of task templates
* added arguments
* added first stub for task config from file
* completed package.xml and CMakeLists.txt
* added script and tested the runner working
* first fully working version
* 

    * added shoft_to_now for testing
    * made scheduler call optional

* more generic name
* renamed ical to gcal
* Contributors: Marc Hanheide
```
## mdp_plan_exec

```
* code clean
  better tracking of execution to allow for general co-safe ltl specs
  correct behaviour when robot is already in influence area of target
* code clean + better user feedback on initialisation
* add dependencies
* fixing version and license
* prepare for release
* code clean and adding policy executor node
* proper argument handling
* expected travel times now call fremen
* client class to get special nodes
* initial stuff for the travel time estimator
* adding node to manage forbidden and safe waypoints
* re-adding prism python client
* building top map mdp from the top map obtained via service call
* package skeleton + basic classes
* Contributors: Bruno Lacerda
```
