### PR TITLE
strands_executive: 0.0.18-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8414,7 +8414,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.17-0
+      version: 0.0.18-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.18-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.17-0`
## gcal_routine
- No changes
## mdp_plan_exec

```
* Update README.md
* update README
* test latex rendering
* Contributors: Bruno Lacerda
```
## scheduler
- No changes
## scipoptsuite
- No changes
## sim_clock
- No changes
## strands_executive_msgs
- No changes
## task_executor
- No changes
## wait_action

```
* Added   strands_executive_msgs to build depend list of wait_action. This should fix #138 <https://github.com/strands-project/strands_executive/issues/138>.
* Contributors: Nick Hawes
```
