### PR TITLE
scitos_2d_navigation: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7816,7 +7816,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_2d_navigation.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_2d_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_2d_navigation` to `0.0.7-0`:
- upstream repository: https://github.com/strands-project/scitos_2d_navigation.git
- release repository: https://github.com/strands-project-releases/scitos_2d_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.6-0`
## scitos_2d_navigation

```
* Merge pull request #56 <https://github.com/strands-project/scitos_2d_navigation/issues/56> from strands-project/local_mb_params
  Use scitos_2d_navigation's own parameters.
* Use scitos_2d_navigation's own parameters.
  Switches to use the scitos_2d_navigation parameters for move_base instead of linking to the strands_movebase copy. I think this is tidier than the alternative of adding a dependency on strands_movebase.
* Merge pull request #54 <https://github.com/strands-project/scitos_2d_navigation/issues/54> from Jailander/hydro-devel
  avoiding planning through unknown areas
* avoiding planning through unknown areas
* Contributors: Bruno Lacerda, Chris Burbridge, Jaime Pulido Fentanes, Marc Hanheide
```
