### PR TITLE
scitos_drivers: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7867,7 +7867,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_drivers.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_drivers` to `0.1.3-0`:
- upstream repository: https://github.com/strands-project/scitos_drivers.git
- release repository: https://github.com/strands-project-releases/scitos_drivers.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.2-0`
## flir_pantilt_d46

```
* Merge branch 'reset_service' of https://github.com/cburbridge/scitos_drivers into cburbridge-reset_service
  Conflicts:
  flir_pantilt_d46/src/ptu46_node.cc
* Add service to reset/calibrate PTU.
* Add velocity control option as new topic.
* Add service to reset/calibrate PTU.
* Add velocity control option as new topic.
* indigo-0.1.2
* Update changelogs.
* Fix publisher queue_size for indigo.
* indigo-0.1.1
* Manual indigo version bump.
* Contributors: Chris Burbridge
```
## scitos_bringup

```
* indigo-0.1.2
* Update changelogs.
* Fix openni wrapper include.
  Renamed default camera to head_xtion, since the non-strands scitos by default has a head camera not a chest camera attached to the main machine. Removed obsolete publish_tf argument.
* Update for renamed pc_monitor.
* indigo-0.1.1
* Manual indigo version bump.
* Fix s300 launch include.
* Contributors: Chris Burbridge
```
## scitos_drivers

```
* indigo-0.1.2
* Update changelogs.
* indigo-0.1.1
* Manual indigo version bump.
* Add scitos_pc_monitor to metapackage.
* Contributors: Chris Burbridge
```
## scitos_mira

```
* indigo-0.1.2
* Update changelogs.
* indigo-0.1.1
* Manual indigo version bump.
* Contributors: Chris Burbridge
```
## scitos_pc_monitor

```
* indigo-0.1.2
* Update changelogs.
* Fix publisher queue_size for indigo.
* indigo-0.1.1
* Update changelogs.
* Manual indigo version bump.
* Prepare pc_monitor for move to scitos_drivers
* Contributors: Chris Burbridge
```
