### PR TITLE
strands_systems: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8530,7 +8530,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_systems.git
-      version: 0.0.8-0
+      version: 0.0.9-0
   strands_ui:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_systems` to `0.0.9-0`:
- upstream repository: https://github.com/strands-project/strands_systems.git
- release repository: https://github.com/strands-project-releases/strands_systems.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.8-0`
## strands_bringup

```
* Setting default of with_human_aware to true
  Now that https://github.com/strands-project/strands_hri/pull/91 is merged, human aware navigation dynamically subscribes and unsubscribes from the ppl perception pipeline. this means:
  * If the edge uses human aware navigation, everything works as expected. While the robot is driving it subscribes to the ppl perception. If not goal is active it unsubscribes.
  * If the edge uses move_base, human ware navigation is unsubscribed from the ppl perception, not causing any processing.
  * If the ppl perception is not running, human aware navigation behaves like move_base + some gazing behaviour
  Therefore, having it running by default does not cause additional load on the CPU if it is not used but it prevents confusion if it is used in the edge but not running.
* Adding strands_hri to package xml of strands_bringup.
* Added human_aware_navigation and dependencies to strands_navigation.launch. See #101 <https://github.com/strands-project/strands_systems/issues/101>. Default behaviour is unchanged. To run with human_aware_navigation, start with .
* indigo-0.0.8
* Contributors: Chris Burbridge, Christian Dondrup
```
