### PR TITLE
strands_recovery_behaviours: 0.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8498,7 +8498,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_recovery_behaviours.git
-      version: 0.0.11-0
+      version: 0.0.12-0
     source:
       type: git
       url: https://github.com/strands-project/strands_recovery_behaviours.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_recovery_behaviours` to `0.0.12-0`:
- upstream repository: https://github.com/strands-project/strands_recovery_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_recovery_behaviours.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.11-0`
## backoff_behaviour
- No changes
## backtrack_behaviour
- No changes
## strands_human_help
- No changes
## strands_monitored_nav_states
- No changes
## strands_recovery_behaviours

```
* Adding walking_group_recovery to meta package
  Closes #39 <https://github.com/strands-project/strands_recovery_behaviours/issues/39>
* Contributors: Christian Dondrup
```
## walking_group_recovery

```
* Forgot to specify .ros
* Changed to the correct music set
* Integrated the player and media server stuff
* Contributors: Nils Bore
```
