### PR TITLE
strands_morse: 0.0.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8486,7 +8486,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.0.15-0
+      version: 0.0.16-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.0.16-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.15-0`
## strands_morse

```
* Merge pull request #114 <https://github.com/strands-project/strands_morse/issues/114> from nilsbore/no_machine_tags
  Remove / from beginning of camera topics
* Merge pull request #113 <https://github.com/strands-project/strands_morse/issues/113> from strands-project/no_machine_tags
  changed AAF sim to use full-scale openNI simulation
* Changed the camera frame so that they work with OpenNI topics generation
* Merge pull request #111 <https://github.com/strands-project/strands_morse/issues/111> from strands-project/cburbridge-remove_abs_path
  Remove absolute path for G4S map.
* made aaf demo to use the full-scale OpenNI simulation including all its topics.
* removed the machine tags as they stopped this to be included from another launch file (aaf_sim).
  In fact, these tags don't make much sense in strands_morse, I believe.
* Remove absolute path for G4S map.
* Merge pull request #110 <https://github.com/strands-project/strands_morse/issues/110> from kunzel/indigo-devel
  add map of simulated environment (g4s)
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_morse into indigo-devel
* add map of simulated environment
* Merge pull request #109 <https://github.com/strands-project/strands_morse/issues/109> from kunzel/indigo-devel
  add launch file for navigation and real-world map
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_morse into indigo-devel
* add launch file for navigation and real-world map
* Contributors: Chris Burbridge, Lars Kunze, Marc Hanheide, Nick Hawes, Nils Bore
```
