### PR TITLE
strands_morse: 0.0.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8532,7 +8532,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.0.16-0
+      version: 0.0.17-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.0.17-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.16-0`
## strands_morse

```
* Merge pull request #115 <https://github.com/strands-project/strands_morse/issues/115> from strands-project/fixed_machine_tags
  fixing the machine tags (once again)
* Hopefully addressing the problem in https://github.com/strands-project/strands_morse/commit/e7b6257f1ce892e15e591e8005a1768a23e9473d#commitcomment-10417236
* Contributors: Marc Hanheide
```
