### PR TITLE
strands_executive_behaviours: 0.0.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8501,7 +8501,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive_behaviours.git
-      version: 0.0.12-2
+      version: 0.0.13-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive_behaviours.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive_behaviours` to `0.0.13-0`:
- upstream repository: https://github.com/strands-project/strands_executive_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_executive_behaviours.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.12-2`
## routine_behaviours

```
* Minor clean up.
* Add day off check to idle trigger.
  This fixes #19 <https://github.com/strands-project/strands_executive_behaviours/issues/19>.
* Added titles for nicer deliverables
* added routine behaviour docs
* Resetting idle count after idle action
* Now doing a slightly smarter tour duration estimate
* Contributors: Nick Hawes
```
