### PR TITLE
fremen: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1848,7 +1848,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/fremen.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/strands-project/fremen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fremen` to `0.1.2-0`:
- upstream repository: https://github.com/strands-project/fremen.git
- release repository: https://github.com/strands-project-releases/fremen.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.1-0`
## fremengrid
- No changes
## fremenserver

```
* Added libs too. This fixes #11 <https://github.com/strands-project/fremen/issues/11>.
* Added install target for fremenserver. This fixes #11 <https://github.com/strands-project/fremen/issues/11>.
* Contributors: Nick Hawes
```
## frenap

```
* Fixes for compilation on OS X.
* Contributors: Nick Hawes
```
## froctomap
- No changes
