### PR TITLE
strands_ui: 0.0.19-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8693,7 +8693,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_ui.git
-      version: 0.0.18-0
+      version: 0.0.19-0
     source:
       type: git
       url: https://github.com/strands-project/strands_ui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_ui` to `0.0.19-0`:
- upstream repository: https://github.com/strands-project/strands_ui.git
- release repository: https://github.com/strands-project-releases/strands_ui.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.18-0`
## mary_tts
- No changes
## mongodb_media_server

```
* Change web interface page title.
* Fix file set selection by name.
* Contributors: Chris Burbridge
```
## music_player

```
* Adding parameter for audio priority to music_player
* Contributors: Christian Dondrup
```
## pygame_managed_player

```
* fixes #81 <https://github.com/strands-project/strands_ui/issues/81>: add priorities announcements on pause and new stop() method
* Contributors: Marc Hanheide
```
## sound_player_server

```
* [sound_player_server] Enabling configuration of priority and volume
* Contributors: Christian Dondrup
```
## strands_ui
- No changes
## strands_webserver
- No changes
