### PR TITLE
strands_apps: 0.1.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8483,13 +8483,14 @@ repositories:
       - reconfigure_inflation
       - roslaunch_axserver
       - state_checker
+      - static_transform_manager
       - strands_apps
       - strands_emails
       - topic_republisher
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_apps.git
-      version: 0.1.4-0
+      version: 0.1.5-0
     source:
       type: git
       url: https://github.com/strands-project/strands_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.1.5-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.4-0`
## static_transform_manager

```
* homogenised version numbers
* New static_transform_manager package.
* Contributors: Chris Burbridge, Marc Hanheide
```
