### PR TITLE
strands_navigation: 0.0.30-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8586,12 +8586,13 @@ repositories:
       - pose_initialiser
       - strands_navigation
       - strands_navigation_msgs
+      - topological_logging_manager
       - topological_navigation
       - topological_utils
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.29-0
+      version: 0.0.30-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.30-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.29-0`
## topological_logging_manager

```
* fixing issue with topological navigation stats logging in policy execution
* Being able to easily switch between current and closest node for detection.
* Using service to look up edges
  Added install targets and readme.
* Finishing basic functionality.
  Node subscribes to current edge and topic and checks against the white list if it is in it. If so, publish true, false in all other cases.
  Adding a whitelist that allows all nodes. Triggered by keyword ALL. Therefore no node can ever be named ALL.
* First commit of logging manager.
  No real functionality but allows @lucasb-eyer to work on his node depending on it.
* Contributors: Christian Dondrup, Jaime Pulido Fentanes
```
