### PR TITLE
strands_executive: 0.0.19-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8510,7 +8510,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.18-0
+      version: 0.0.19-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.19-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.18-0`
## gcal_routine

```
* now uses the top launch file to make the test work...
* better unit testing including scheduler
* gcal_routine now using factory task service
* Contributors: Marc Hanheide
```
## mdp_plan_exec

```
* Integrated mdp travel time service.
  The current setup allows and code switch back to top nav if necessary. Tested with both.
  This also fixes a problem in the /mdp_plan_exec/get_expected_travel_times_to_waypoint service where it was expecting a duration for epoch but the service definition was of int.
* Contributors: Nick Hawes
```
## scheduler
- No changes
## scipoptsuite
- No changes
## sim_clock
- No changes
## strands_executive_msgs

```
* added documentation and made it a *real* abstract class
* Fixing a typo in abstract_task_server
* finished a first draft of the factory from a YAML string
* using yaml to instantiate tasks
* Integrated mdp travel time service.
  The current setup allows and code switch back to top nav if necessary. Tested with both.
  This also fixes a problem in the /mdp_plan_exec/get_expected_travel_times_to_waypoint service where it was expecting a duration for epoch but the service definition was of int.
* removed invalid comments
* moved abstract_task_server into strands_executive_msgs and refactored wait_action
* added an abstract_task_server
* Contributors: Christian Dondrup, Marc Hanheide, Nick Hawes
```
## task_executor

```
* Added rostest for task_executor with scheduler
* Added param to task_executor to configure navigation type.
  Refactored launch and test files to use this flag.
* Switching to top nav in the fifo executor.
* Integrating MDP policy execution with switch to return to top nav if necessary.
* Integrated mdp travel time service.
  The current setup allows and code switch back to top nav if necessary. Tested with both.
  This also fixes a problem in the /mdp_plan_exec/get_expected_travel_times_to_waypoint service where it was expecting a duration for epoch but the service definition was of int.
* moved abstract_task_server into strands_executive_msgs and refactored wait_action
* made wait_action to use the new abstract_task_server as an example
* added an abstract_task_server
* Contributors: Marc Hanheide, Nick Hawes
```
## wait_action

```
* added documentation and made it a *real* abstract class
* moved abstract_task_server into strands_executive_msgs and refactored wait_action
* made wait_action to use the new abstract_task_server as an example
* Contributors: Marc Hanheide
```
