### PR TITLE
scitos_apps: 0.0.17-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -7955,6 +7955,7 @@ repositories:
   scitos_apps:
     release:
       packages:
+      - ptu_follow_frame
       - scitos_apps
       - scitos_cmd_vel_mux
       - scitos_dashboard
@@ -7965,7 +7966,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_apps.git
-      version: 0.0.16-0
+      version: 0.0.17-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_apps` to `0.0.17-0`:
- upstream repository: https://github.com/strands-project/scitos_apps.git
- release repository: https://github.com/strands-project-releases/scitos_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.16-0`
## ptu_follow_frame

```
* Add ptu_follow_frame readme.
* New ptu_follow_frame package.
* Contributors: Chris Burbridge
```
