### PR TITLE
strands_hri: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8621,6 +8621,10 @@ repositories:
   strands_hri:
     release:
       packages:
+      - bellbot_action_server
+      - bellbot_gui
+      - bellbot_scheduler
+      - hrsi_representation
       - strands_gazing
       - strands_hri
       - strands_hri_launch
@@ -8632,7 +8636,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_hri.git
-      version: 0.0.7-3
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/strands-project/strands_hri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_hri` to `0.0.8-0`:
- upstream repository: https://github.com/strands-project/strands_hri.git
- release repository: https://github.com/strands-project-releases/strands_hri.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.7-3`
## bellbot_action_server

```
* bellbot_action_server changed to interruptible
  pending to check whether individual states are also interruptible
* preparing bellbot_action_server for release 0.0.7
* action server cleanup on stop/interrupt
* florence virtual keyboard
* service handlers exit with returning their responses now
* adding empty service for feedback
* Removing feedback service
* mv files into dir
* Contributors: Jaime Pulido Fentanes, Yiannis Gatsoulis
```
## bellbot_gui

```
* closes #90 <https://github.com/strands-project/strands_hri/issues/90> - preparing bellbot_gui for release 0.0.7
* florence virtual keyboard
* gui2 should be OK for WaitingForGoal
* uncache auto-generated webpage and add it to .gitignore
* gui WaitingForGoal should be OK now
* Merge branch 'hydro-devel' of github.com:strands-project/strands_hri into hydro-devel
  Conflicts:
  bellbot_gui/src/gui.py
* gui2 check
* rosparam for map name
* adding empty service for feedback
* creeating dir
* Contributors: Jaime Pulido Fentanes, Yiannis Gatsoulis
```
## bellbot_scheduler

```
* bellbot_scheduler preparing for release 0.0.7
* fixing CMakeLists.txt for #92 <https://github.com/strands-project/strands_hri/issues/92>
* creeating dir
* Contributors: Jaime Pulido Fentanes, Marc Hanheide, Yiannis Gatsoulis
```
## hrsi_representation

```
* Adjusted cmake and package files
* First working version of the onlie qtc creation.
* Training now works.
* Basic functionality of reading files and transforming the content into qtc
* Contributors: Christian Dondrup
```
