### PR TITLE
strands_perception_people: 1.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8702,11 +8702,12 @@ repositories:
       - strands_head_orientation
       - strands_perception_people
       - upper_body_detector
+      - vision_people_logging
       - visual_odometry
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 1.0.0-0
+      version: 1.1.0-0
     source:
       type: git
       url: https://github.com/strands-project/strands_perception_people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `1.1.0-0`:
- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.0-0`
## vision_people_logging

```
* Increase slop because UBD publishes at 10hz.
* Make use of the logging manager in vision_people_logging.
* Added node for logging UpperBodyDetections (UBDs).
* Contributors: lucasb-eyer
```
