### PR TITLE
fremen: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1906,7 +1906,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/fremen.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/strands-project/fremen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fremen` to `0.1.3-0`:
- upstream repository: https://github.com/strands-project/fremen.git
- release repository: https://github.com/strands-project-releases/fremen.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.2-0`
## fremengrid
- No changes
## fremenserver

```
* Minor bug in last added data timestamp removed.
* Separate orders for the states in the forecast action.
* Forecast - predicting multiple states
* Contributors: Jaime Pulido Fentanes, Tom Krajnik
```
## frenap
- No changes
## froctomap
- No changes
