### PR TITLE
strands_hri: 0.0.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8730,7 +8730,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_hri.git
-      version: 0.0.8-0
+      version: 0.0.9-0
     source:
       type: git
       url: https://github.com/strands-project/strands_hri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_hri` to `0.0.9-0`:
- upstream repository: https://github.com/strands-project/strands_hri.git
- release repository: https://github.com/strands-project-releases/strands_hri.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.8-0`
## bellbot_action_server

```
* tiding up fixing files
* Contributors: Jaime Pulido Fentanes
```
## bellbot_gui

```
* adding missing dependencies
* tiding up fixing files
* Contributors: Jaime Pulido Fentanes
```
## bellbot_scheduler

```
* tiding up fixing files
* Contributors: Jaime Pulido Fentanes
```
## hrsi_representation
- No changes
## strands_gazing
- No changes
## strands_hri
- No changes
## strands_hri_launch
- No changes
## strands_human_aware_navigation

```
* Changing default and min values for some of the params
  Min distance can now be 0.0. The problem is that, the robot will stop moving before the min distance is reached, because the transitional velocity will be too low for the planner to find a valid plan. This PR sets more conservative default values as wll to allow for easier testing and not having the robot stop because of @jsantos all the time ;)
  During the pre-deployment, we have to find a suitable set for AAF.
* Setting rot vel to 0 if trans vel is below magic number.
* Contributors: Christian Dondrup
```
## strands_human_following
- No changes
## strands_interaction_behaviours
- No changes
## strands_simple_follow_me
- No changes
## strands_visualise_speech
- No changes
