### PR TITLE
strands_movebase: 0.0.19-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8754,10 +8754,11 @@ repositories:
       - movebase_state_service
       - strands_description
       - strands_movebase
+      - strands_navfn
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_movebase.git
-      version: 0.0.18-0
+      version: 0.0.19-0
     source:
       type: git
       url: https://github.com/strands-project/strands_movebase.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_movebase` to `0.0.19-0`:
- upstream repository: https://github.com/strands-project/strands_movebase.git
- release repository: https://github.com/strands-project-releases/strands_movebase.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.18-0`
## strands_navfn

```
* prepare for release
* removing navfn maintainers so they dont get spammed by our errors
* added missing strands_navfn
* reading default_tolerance param before generating global plans
* adding  copy of navfn package, with lots of strands_* prefixes to avoid conflicts with navfn
* Contributors: Bruno Lacerda
```
