### PR TITLE
strands_recovery_behaviours: 0.0.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8837,7 +8837,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_recovery_behaviours.git
-      version: 0.0.12-0
+      version: 0.0.13-0
     source:
       type: git
       url: https://github.com/strands-project/strands_recovery_behaviours.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_recovery_behaviours` to `0.0.13-0`:
- upstream repository: https://github.com/strands-project/strands_recovery_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_recovery_behaviours.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.12-0`
## backoff_behaviour
- No changes
## backtrack_behaviour

```
* Extended the wait time a bit
* Corrected message assignment
* Changed to check if correct plan with service instead
* Moved speaking from monitored nav states to backtrack, with check if it got a global plan
* Contributors: Nils Bore, Rares Ambrus
```
## strands_human_help

```
* only complain about lack of proper help when help was offered
* first stuff to allow recover states to be deactivated
* Contributors: Bruno Lacerda
```
## strands_monitored_nav_states

```
* bug fixes+code clean
* update recover states to be subclasses of new RecoverState - to allow on the fly enable/disable
* Merge branch 'hydro-devel' of https://github.com/strands-project/strands_recovery_behaviours into hydro-devel
  Conflicts:
  strands_monitored_nav_states/src/strands_monitored_nav_states/recover_nav_states.py
* Moved speaking from monitored nav states to backtrack, with check if it got a global plan
* first stuff to allow recover states to be deactivated
* Contributors: Bruno Lacerda, Nils Bore
```
## strands_recovery_behaviours
- No changes
## walking_group_recovery

```
* Using parameters to set audio priorities and volumes in walking group recovery
* Not crashing if no files in data set
* update recover states to be subclasses of new RecoverState - to allow on the fly enable/disable
* update walking group toggle recovery service with new message typw
* Contributors: Bruno Lacerda, Christian Dondrup, Nils Bore
```
