### PR TITLE
strands_navigation: 0.0.31-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8779,7 +8779,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.30-0
+      version: 0.0.31-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.31-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.30-0`
## joy_map_saver
- No changes
## message_store_map_switcher
- No changes
## monitored_navigation

```
* set n_tries to 1 when it doesnt come from userdata
* RecoverState class to allow enable/disable of certain recoveries on the fly
* extra try/catch statements in the logging
* stop instantiating new classes all the time - making sure services with the same name arent created
* first stuff to allow deactivating recover states
* Contributors: Bruno Lacerda
```
## nav_goals_generator
- No changes
## pose_initialiser
- No changes
## strands_navigation

```
* Adding topological_logging_manager to meta package
  Closes #212 <https://github.com/strands-project/strands_navigation/issues/212>
* Contributors: Christian Dondrup
```
## strands_navigation_msgs

```
* change mon nav events to allow for more failures to be logged
* Adding Services:
  * /topological_map_manager/add_content_to_node: adds content to a node
  * /topological_map_manager/get_tags: get a list of tags to in the current topological map
  * /topological_map_manager/rm_tag_from_node: removes a tag from a list of nodes
* Contributors: Bruno Lacerda, Jaime Pulido Fentanes
```
## topological_logging_manager
- No changes
## topological_navigation

```
* fixing issues tested
* typo
* changing prints to rospy.loggerr
* Improving error handling
* adding service to get tagged nodes ordered by distance and minor bug fix on topological navigation
* Policy execution doesn't do move_base to the waypoint when the waypoint is localised by topic
* localisation by topic only works if the robot is in the influence zone of the node, migrate script now adds JSON string for localisation on ChargingPoint
* Implementing Localise By topic and No go nodes exceptions
* Topological prediction now uses forecast service
* Improving time estimation
* returning only edge_id in topological prediction
* Fixing issues with topological Prediction
* second part of previous commit
* checking sanity on migrate scripts
* Topological navigation doesn't use nasty old Classes anymore
* adding search route script
* Contributors: Jaime Pulido Fentanes
```
## topological_utils

```
* localisation by topic only works if the robot is in the influence zone of the node, migrate script now adds JSON string for localisation on ChargingPoint
* Fixing issues with topological Prediction
* second part of previous commit
* checking sanity on migrate scripts
* Contributors: Jaime Pulido Fentanes
```
