### PR TITLE
strands_systems: 0.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8869,7 +8869,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_systems.git
-      version: 0.0.9-0
+      version: 0.0.10-0
   strands_ui:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_systems` to `0.0.10-0`:
- upstream repository: https://github.com/strands-project/strands_systems.git
- release repository: https://github.com/strands-project-releases/strands_systems.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.9-0`
## strands_bringup

```
* Adding parmaters to start mary on different machine.
* Contributors: Christian Dondrup
```
