### PR TITLE
scitos_common: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8110,7 +8110,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_common.git
-      version: 0.1.6-1
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_common` to `0.1.7-0`:
- upstream repository: https://github.com/strands-project/scitos_common.git
- release repository: https://github.com/strands-project-releases/scitos_common.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.6-1`
## scitos_common
- No changes
## scitos_description

```
* Starting state publisher in robot namespace, setting robot description and robot/robot_description
* Replacing deprecated xarco include
  Gets rid of the stupid warning when launched.
* Contributors: Christian Dondrup
```
## scitos_msgs
- No changes
