### PR TITLE
strands_executive: 0.0.20-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8713,7 +8713,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.19-0
+      version: 0.0.20-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.20-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.19-0`
## gcal_routine

```
* added documentation in README.md
* added priorities to gcal routine
* Contributors: Marc Hanheide
```
## mdp_plan_exec

```
* clean unneeded prints
* added extra print for the string created by travel times estimation
* kick typo fix
* added prints to figure out bottleneck
* filling mdp with edge predictions from topological nav
* getting node to die cleanly
* Contributors: Bruno Lacerda
```
## scheduler

```
* remove text "TODO" for solved lines
* Uncommented priorities in example code
* ScipUser - fixed bug with creating tcons
  Scheduler node - test if times s, e are valid
* added warning when pairs creation fail
* Extension of node with diagnostic comments
* changed criterion to  decide task, now same as in ICRA paper
* fixed bug with writtin to a file
* supporting code if we need to propagate priorities to scheduler
* clean-up verson of scheduler, as on-demand  task are not propagate to scheduler, deteled code which was not needed
* Pairs return now -1 when detecting flaw in input data, -2 when creating flaw themselves
* fixed bug in pairs causing scheduler to fail. Also fix bug with -1 constraint, which was causing that schedule was found for non existing solutions
  extended scheduled_task_executor to throw away tasks with  priorities
* Delete readme.md
* Attempt to have readme files in subfolders
* Uncommented priorities in example code
* ScipUser - fixed bug with creating tcons
  Scheduler node - test if times s, e are valid
* added warning when pairs creation fail
* Extension of node with diagnostic comments
* changed criterion to  decide task, now same as in ICRA paper
* fixed bug with writtin to a file
* supporting code if we need to propagate priorities to scheduler
* clean-up verson of scheduler, as on-demand  task are not propagate to scheduler, deteled code which was not needed
* Pairs return now -1 when detecting flaw in input data, -2 when creating flaw themselves
* fixed bug in pairs causing scheduler to fail. Also fix bug with -1 constraint, which was causing that schedule was found for non existing solutions
  extended scheduled_task_executor to throw away tasks with  priorities
* deleted readme
* Delete readme.md
* Attempt to have readme files in subfolders
* Contributors: Lenka, Lenka Mudrova
```
## scipoptsuite
- No changes
## sim_clock
- No changes
## strands_executive_msgs

```
* this abstract_task_server should have no change, I just messed up my git
* Task message has now priorities field
* this abstract_task_server should have no change, I just messed up my git
* Task message has now priorities field
* Contributors: Lenka
```
## task_executor

```
* Merge branch 'hydro-release' of https://github.com/mudrole1/strands_executive into hydro-release
  Conflicts:
  task_executor/scripts/scheduled_task_executor.py
* Fixed some bugs in priorities handling, submitting testing file
* Added functionality of priorities and withdrawing tasks
* fixed bug in pairs causing scheduler to fail. Also fix bug with -1 constraint, which was causing that schedule was found for non existing solutions
  extended scheduled_task_executor to throw away tasks with  priorities
* try_schedule now tries to thow away some tasks in order to try to schedule smaller batch
* Removed fifo tester from make file.
  The fifo stuff is not actually used in the full system. Given that the scheduler test is in there now we are already testing all the things that this test.
* Fixed some bugs in priorities handling, submitting testing file
* Extended wait duration to see if that accounts for #155 <https://github.com/strands-project/strands_executive/issues/155>
* Correcting order of values returned from demand task service call.
  Once the task_id number grew larger this was no longer interpreted (incorrectly) as a boolean, causing #163 <https://github.com/strands-project/strands_executive/issues/163>.
  This fixes #163 <https://github.com/strands-project/strands_executive/issues/163>.
* Removed deprecated code.
* Added locking in log methods to prevent concurrent calls to message store service. This should fix #160 <https://github.com/strands-project/strands_executive/issues/160>
* removing frenap from dependencies
* removing frenap from launch file
* Added locking arond mdp expected time call so that code which calls it directly does not have concurrency issues with the other expected time call.
* Not using blank start_after for epoch.
  This should address #157 <https://github.com/strands-project/strands_executive/issues/157>
* Added functionality of priorities and withdrawing tasks
* fixed bug in pairs causing scheduler to fail. Also fix bug with -1 constraint, which was causing that schedule was found for non existing solutions
  extended scheduled_task_executor to throw away tasks with  priorities
* Decreasing fudge factor now actual data is being used.
* Using full vector from mdp travel service.
  This closes #152 <https://github.com/strands-project/strands_executive/issues/152>
* try_schedule now tries to thow away some tasks in order to try to schedule smaller batch
* Contributors: Bruno Lacerda, Lenka, Nick Hawes
```
## wait_action

```
* possible to overwrite name of node
* made wait_action interruptible configurable
* fixes #151 <https://github.com/strands-project/strands_executive/issues/151>
* Contributors: Marc Hanheide
```
