### PR TITLE
strands_navigation: 0.0.32-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8800,7 +8800,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.31-0
+      version: 0.0.32-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.32-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.31-0`
## joy_map_saver
- No changes
## message_store_map_switcher
- No changes
## monitored_navigation
- No changes
## nav_goals_generator
- No changes
## pose_initialiser
- No changes
## strands_navigation
- No changes
## strands_navigation_msgs
- No changes
## topological_logging_manager
- No changes
## topological_navigation

```
* emergency behaviours launch file
* updating service list when most services will be needed
* Adding Emergency Behaviours
* fixing action server bug
* Contributors: Jaime Pulido Fentanes
```
## topological_utils

```
* fixing bug in insert map that I inserted myself
* Contributors: Jaime Pulido Fentanes
```
