### PR TITLE
strands_morse: 0.0.19-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8761,7 +8761,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.0.18-0
+      version: 0.0.19-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.0.19-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.18-0`
## strands_morse

```
* Merge pull request #120 <https://github.com/strands-project/strands_morse/issues/120> from cdondrup/indigo-devel
  No camera, wireframe version of aaf.
* No camera, wireframe version of aaf.
* Contributors: Christian Dondrup, Marc Hanheide
```
