### PR TITLE
strands_social: 0.0.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8877,7 +8877,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_social.git
-      version: 0.0.12-0
+      version: 0.0.13-0
     source:
       type: git
       url: https://github.com/strands-project/strands_social.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_social` to `0.0.13-0`:
- upstream repository: https://github.com/strands-project/strands_social.git
- release repository: https://github.com/strands-project-releases/strands_social.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.12-0`
## card_image_tweet

```
* changing order of tweeting publishing trying to tackle slow network problems
* Contributors: Jaime Pulido Fentanes
```
## datamatrix_read
- No changes
## fake_camera_effects
- No changes
## image_branding

```
* copying header to output image
* adding image superimposer
* Contributors: Jailander
```
## social_card_reader
- No changes
## strands_social
- No changes
## strands_tweets

```
* changing order of tweeting publishing trying to tackle slow network problems
* Contributors: Jaime Pulido Fentanes
```
