### PR TITLE
strands_executive: 0.0.21-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8713,7 +8713,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.20-0
+      version: 0.0.21-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.21-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.20-0`
## gcal_routine

```
* calling the factory method with pre-populated YAML to allows task to know these values already
* Contributors: Marc Hanheide (at AAF control PC)
```
## mdp_plan_exec

```
* check if target waypoint exists before getting expected travel times or executing policies
* ignore waypoints visited after influence area of target waypoint has been reached
* Contributors: Bruno Lacerda
```
## scheduler

```
* change of my email in the scheduler
* Contributors: Lenka
```
## scipoptsuite
- No changes
## sim_clock
- No changes
## strands_executive_msgs
- No changes
## task_executor

```
* just change launch files for new name of wait_action, also changed default value to be interruptible
* Contributors: Lenka
```
## wait_action

```
* determine wait time from scheduled window in factory
* just change launch files for new name of wait_action, also changed default value to be interruptible
* Contributors: Lenka, Marc Hanheide (at AAF control PC)
```
