### PR TITLE
strands_ui: 0.0.21-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8904,7 +8904,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_ui.git
-      version: 0.0.20-0
+      version: 0.0.21-0
     source:
       type: git
       url: https://github.com/strands-project/strands_ui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_ui` to `0.0.21-0`:
- upstream repository: https://github.com/strands-project/strands_ui.git
- release repository: https://github.com/strands-project-releases/strands_ui.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.20-0`
## mary_tts
- No changes
## mongodb_media_server
- No changes
## music_player
- No changes
## pygame_managed_player
- No changes
## sound_player_server

```
* Namespaced sound_player_server service
* Contributors: Nils Bore
```
## strands_ui
- No changes
## strands_webserver
- No changes
