### PR TITLE
strands_morse: 0.0.21-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8761,7 +8761,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.0.20-0
+      version: 0.0.21-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.0.21-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.20-0`
## strands_morse

```
* Merge pull request #121 <https://github.com/strands-project/strands_morse/issues/121> from cburbridge/patch-1
  Adds G4S install target.
* Merge pull request #118 <https://github.com/strands-project/strands_morse/issues/118> from hawesie/indigo-devel
  Added topological map file for g4s.
* Add G4S install target.
* Swithced to human aware
* Added office-sized influence zones and corrected a couple of edges.
* Added topological map file for g4s.
  This should be added to teh datacentre as follows
```

  rosrun topological_utils insert_map.py `rospack find strands_morse`/g4s/mapsg4s_sim.tplg g4s_sim g4s_sim
  rosrun topological_utils migrate.py

```
  The second command is needed to update the inserted map to the current format.
  The map currently has no docking station to the charging point is reaching be normal movement (human-aware).
* Contributors: Chris Burbridge, Marc Hanheide, Nick Hawes
```
