### PR TITLE
strands_apps: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8698,7 +8698,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_apps.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/strands-project/strands_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.1.7-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.6-0`
## door_pass
- No changes
## marathon_reporter
- No changes
## odometry_mileage
- No changes
## pose_extractor
- No changes
## ramp_climb
- No changes
## reconfigure_inflation
- No changes
## roslaunch_axserver
- No changes
## state_checker
- No changes
## static_transform_manager

```
* Add is_ok flag to StopTransformation response.
* Contributors: Chris Burbridge
```
## strands_apps

```
* adding error handling and strands emails to metapackage
* Contributors: Jailander
```
## strands_emails

```
* adding error handling and strands emails to metapackage
* Contributors: Jailander
```
## topic_republisher
- No changes
