### PR TITLE
strands_hri: 0.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8755,7 +8755,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_hri.git
-      version: 0.0.10-0
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/strands-project/strands_hri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_hri` to `0.0.11-0`:
- upstream repository: https://github.com/strands-project/strands_hri.git
- release repository: https://github.com/strands-project-releases/strands_hri.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.10-0`
## bellbot_action_server

```
* reverting manually changing release numbers
* 0.0.11
* tidy up bellbot_action_server
* Contributors: Yiannis Gatsoulis
```
## bellbot_gui

```
* reverting manually changing release numbers
* 0.0.11
* install targets
* added locale support for user feedback
* removed ros2djs from feedback.html
* read deployment from rosparam, also forgot to mention there is limited support for locale from previous commit
* tidying up
* bellbot_gui uses bellbot deployment dir for writing
* user feedback now is written in /home/yiannis/.ros/bellbot/
* get destinations types from param server
* removed scripts/foo.py and ignore jetbrains IDE
* Contributors: Yiannis Gatsoulis
```
## bellbot_scheduler
- No changes
## hrsi_representation
- No changes
## strands_gazing
- No changes
## strands_hri
- No changes
## strands_hri_launch
- No changes
## strands_human_aware_navigation
- No changes
## strands_human_following
- No changes
## strands_interaction_behaviours
- No changes
## strands_simple_follow_me
- No changes
## strands_visualise_speech
- No changes
