### PR TITLE
strands_executive: 0.0.22-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8743,7 +8743,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.21-0
+      version: 0.0.22-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.22-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.21-0`
## gcal_routine

```
* fixed to use UTC
* Contributors: Marc Hanheide (at AAF control PC)
```
## mdp_plan_exec

```
* mdp now uses ``topological_map_name `` parameter instead of getting it as an argument
* check for white spaces in node names and edge ids, and raise exception if found
* only advertise services and actions once everything else is initialised
* replace ',' by '.' before trying to convert string to float. fix issue for locales where , is used as the decimal
* Contributors: Bruno Lacerda
```
## scheduler
- No changes
## scipoptsuite
- No changes
## sim_clock
- No changes
## strands_executive_msgs

```
* Added extra constants for routine start/stop/
* Contributors: Nick Hawes
```
## task_executor

```
* Added a verbose option to the schedule printer.
  If you do rosparam set schedule_verbose true you can now see the tasks which are scheduled. Use rosparam set schedule_limit 10 etc. to limit the number of tasks printed.
* filtering extra daily tasks to remove impossible ones
* Utility functions for preceding commits.
* Added parameter relaxed_nav to prevent execution killing navigation if it tasks too long.
  rosparam set relaxed_nav true if you want your navigation actions to have a very long timeout. Set it back to false the timeouts will come from the predicted times.  This will only take effect on the next task.
* Added node that prints out task executive event.
  E.g.
  rosrun task_executor task_status.py
  shows
```

  task 2          WayPoint11      NAVIGATION_FAILED       19/04/15 18:55:04
  task 2          WayPoint11      TASK_FAILED     19/04/15 18:55:04
  task 3          WayPoint10      ADDED   19/04/15 18:55:17
  task 3          WayPoint10      TASK_STARTED    19/04/15 18:55:17
  task 3          WayPoint10      NAVIGATION_STARTED      19/04/15 18:55:17

```
* Script now prints out the routines and runtime.
* Added logging of routine start and stop. This is for better overall system analysis.
* Added ability to add tasks to the routine for just the day.
* Dealing with case where task added for scheduling has no start node.
  Tested in simulation and works here.
* mdp now uses ``topological_map_name `` parameter instead of getting it as an argument
* Dealing with case where task added for scheduling has no start node.
  Tested in simulation and works here.
* Contributors: Bruno Lacerda, Nick Hawes
```
## wait_action
- No changes
