### PR TITLE
strands_executive_behaviours: 0.0.14-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8756,7 +8756,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive_behaviours.git
-      version: 0.0.13-0
+      version: 0.0.14-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive_behaviours.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive_behaviours` to `0.0.14-0`:
- upstream repository: https://github.com/strands-project/strands_executive_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_executive_behaviours.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.13-0`
## routine_behaviours

```
* Removed redundant/confusing legacy code.
* Night tasks are now executed in a FIFO manner.
  Use this to fix strands-project/g4s_deployment/18
* Night tasks should now be executed in a FIFO order based on calls to add_night_task.
  This should be used to fix https://github.com/strands-project/g4s_deployment/issues/18
* Added ability to pull in tasks for just the day.
* Contributors: Nick Hawes
```
