### PR TITLE
mongodb_store: 0.1.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4146,7 +4146,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.12-0
+      version: 0.1.13-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.13-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.12-0`
## mongodb_log

```
* Recheck topics at a fixed interval in order to attempt to resubscribe to topics that were missing at startup.
  This closes #126 <https://github.com/strands-project/mongodb_store/issues/126>.
* Changed mongodb_log to not wait for topics to be published, instead subscribing to all the other topics
* Contributors: Nick Hawes, Nils Bore
```
## mongodb_store
- No changes
## mongodb_store_msgs
- No changes
