### PR TITLE
strands_movebase: 0.0.20-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8811,13 +8811,14 @@ repositories:
       packages:
       - calibrate_chest
       - movebase_state_service
+      - param_loader
       - strands_description
       - strands_movebase
       - strands_navfn
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_movebase.git
-      version: 0.0.19-0
+      version: 0.0.20-0
     source:
       type: git
       url: https://github.com/strands-project/strands_movebase.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_movebase` to `0.0.20-0`:
- upstream repository: https://github.com/strands-project/strands_movebase.git
- release repository: https://github.com/strands-project-releases/strands_movebase.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.19-0`
## param_loader

```
* add simple package to dyn reconfigure move_base via yaml files
* Contributors: Bruno Lacerda
```
