### PR TITLE
strands_apps: 0.1.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8732,7 +8732,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_apps.git
-      version: 0.1.7-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/strands-project/strands_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.1.8-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.7-0`
## door_pass

```
* Merge pull request #41 <https://github.com/strands-project/strands_apps/issues/41> from bfalacerda/indigo-devel
  door pass improvements
* add door check script
* update package.xml and CMakeLists
* get topological map name for the logging
* logging door checks to mongo
* getting preemption to work
* door pass tweaks
* use only front langer ranges to calculate trans speed
* 

    * disable/enable recoveries from mon nav when door is closed
    * used selected laser readings for the pass door calculations
    * stop using move base config
    * code clean

* cleaner disable of mon nav recoveries
* disable help from mon nav when door is closed
* Added repeat publishing of stopping commands as they weren't behaving in sim. I think it might be the simulation though.
* Limiting back x and rot value during door pass. This makes things a little slower and less repsonsive, but avoids big dangerous movements
* code clean of door_passing.py
* Contributors: Bruno Lacerda, Nick Hawes, STRANDS
```
## marathon_reporter
- No changes
## odometry_mileage
- No changes
## pose_extractor
- No changes
## ramp_climb
- No changes
## reconfigure_inflation
- No changes
## roslaunch_axserver
- No changes
## state_checker
- No changes
## static_transform_manager
- No changes
## strands_apps
- No changes
## strands_emails
- No changes
## topic_republisher
- No changes
