### PR TITLE
strands_qsr_lib: 0.0.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8879,7 +8879,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_qsr_lib.git
-      version: 0.0.6-0
+      version: 0.0.7-0
     source:
       type: git
       url: https://github.com/strands-project/strands_qsr_lib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_qsr_lib` to `0.0.7-0`:
- upstream repository: https://github.com/strands-project/strands_qsr_lib.git
- release repository: https://github.com/strands-project-releases/strands_qsr_lib.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.6-0`
## qsr_lib

```
* changed in qsrs/arg_distance the qsrs_for_default to not include mirrors and be alphabetically sorted
* changed to sorter code rcc3 custom checks for qsrs_for (same to arg_distance corrected one)
* fixed qsrs_for bug that did not perform correctly custom check in qsr_arg_relations_distance
* arg_relations_distance QSR
* added doc to qsr_abstraclass.custom_checks_for_qsrs_for, added rcc3.custom_checks_for_qsrs_for, closes #32 <https://github.com/strands-project/strands_qsr_lib/issues/32> which was OK
* closes #30 <https://github.com/strands-project/strands_qsr_lib/issues/30> and #26 <https://github.com/strands-project/strands_qsr_lib/issues/26>
* Contributors: Yiannis Gatsoulis
```
## strands_qsr_lib
- No changes
