### PR TITLE
strands_navigation: 0.0.33-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8826,6 +8826,7 @@ repositories:
   strands_navigation:
     release:
       packages:
+      - emergency_behaviours
       - joy_map_saver
       - message_store_map_switcher
       - monitored_navigation
@@ -8839,7 +8840,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.32-0
+      version: 0.0.33-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.33-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.32-0`
## emergency_behaviours

```
* bug fix`#2 <https://github.com/strands-project/strands_navigation/issues/2>`_
* bug fix
* adding safety stop service
* creating emergency behaviours package
* Contributors: Jailander
```
