### PR TITLE
lcas_teaching: 0.1.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -3708,7 +3708,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/lcas_teaching.git
-      version: 0.1.11-0
+      version: 0.1.12-0
     source:
       type: git
       url: https://github.com/LCAS/teaching.git


### PR DESCRIPTION
Increasing version of package(s) in repository `lcas_teaching` to `0.1.12-0`:
- upstream repository: https://github.com/LCAS/teaching.git
- release repository: https://github.com/strands-project-releases/lcas_teaching.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.11-0`
## catkinized_downward
- No changes
## uol_cmp3641m
- No changes
## uol_kobuki_gazebo_plugins
- No changes
## uol_morse_simulator
- No changes
## uol_turtlebot_common

```
* A launch file also starting the navigation and reducing the CPU load by not registering the depth and rgb image.
* Contributors: Christian Dondrup
```
## uol_turtlebot_simulator
- No changes
