### PR TITLE
executive_smach: 2.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1855,8 +1855,8 @@ repositories:
       - smach_ros
       tags:
         release: release/indigo/{package}/{version}
-      url: https://github.com/ros-gbp/executive_smach-release.git
-      version: 2.0.0-0
+      url: https://github.com/strands-project-releases/executive_smach.git
+      version: 2.0.1-0
     source:
       type: git
       url: https://github.com/strands-project/executive_smach.git


### PR DESCRIPTION
Increasing version of package(s) in repository `executive_smach` to `2.0.1-0`:
- upstream repository: https://github.com/strands-project/executive_smach.git
- release repository: https://github.com/strands-project-releases/executive_smach.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.19`
- previous version for package: `2.0.0-0`
## executive_smach

```
* 2.0.0
* Updating changelogs
* Contributors: Jonathan Bohren
```
## smach

```
* Add timeout on termination child states.
  This is to handle cases where child states refuse to terminate. Providing a timeout value allows the concurrence to return that long after a termination event (preempt or child completion) has happened. If the argument is ommitted from the init method then the default behaviour (no timeout) is used.
* Added check for immediate preemption to Concurrence.
  This is necessary because a prior state may have failed to honour a preempt and thus it could be passed to us.
* 2.0.0
* Updating changelogs
* Merging changes, resolving conflicts, from strands-project (@cburbridge)
* cleaning up and removing rosbuild support
* merging groovy and hydro
* Fix get_internal_edges returning list of tuples, not list of lists
* Remove old methods set_userdata
* Remove superfluous parent class declaration 'UserData' from 'Remapper'
* Add local error base class 'SmachError', extending Exception
* Fix syntax errors, doc typos and indentations glitches
* Fixed invalid exception type in concurrence.py
* Checking threads have fully terminated before cleanup of outcomes dict
  This commit uses thread.isAlive() on each concurrent state runner to check for termination of all the threads before continuing. This is necessary as only checking that the outcome has been filled in does not mean the thread has completed; if the thread has not completed it may not yet have called the termination callback. If this loop exits before the termination callback of the last thread is called, then the callback will occasionally be sent an empty dictionary (when the main thread has got to line 305).
* cope with missed state termination notifications
  Concurrent states could terminate and notify _ready_event without the concurrence container realising, as it could be busy checking the outcome values. This makes the concurrency container get stuck on line 250. This commit adds a timeout to the wait to safely cope with missing notifications.
* Adding event for thread synchronization in concurrence and using event not condition in monitor state
* Contributors: Felix Kolbe, Jonathan Bohren, Nick Hawes, Piotr Orzechowski, cburbridge
```
## smach_msgs

```
* 2.0.0
* Updating changelogs
* cleaning up and removing rosbuild support
* merging groovy and hydro
* Add explanations within message definitions
* Contributors: Felix Kolbe, Jonathan Bohren
```
## smach_ros

```
* fixing monitor state callback args and adding unit test for monitor state that modifies userdata
* make ServiceState more robust to termination while waiting for service
* 2.0.0
* Updating changelogs
* smach_ros: Adding rostests to cmakelists
* Merging changes, resolving conflicts, from strands-project (@cburbridge)
* cleaning up and removing rosbuild support
* merging groovy and hydro
* Fixing #28 <https://github.com/strands-project/executive_smach/issues/28> which was introduced by python3 changes
  Introduced in fdf99b1f3674dada7f22ca2636addb596c3294eb
* Listing available goal slots in case of specifying wrong ones
* Fixing #28 <https://github.com/strands-project/executive_smach/issues/28> which was introduced by python3 changes
  Introduced in fdf99b1f3674dada7f22ca2636addb596c3294eb
* Fix syntax errors, doc typos and indentations glitches
* if monitor state prempted before executing, return.
* Adding event for thread synchronization in concurrence and using event not condition in monitor state
* Listing available goal slots in case of specifying wrong ones
* [MonitorState] Make exception handler more verbose
* edited monitor state to allow input and output keys
* Contributors: Boris Gromov, Bruno Lacerda, Felix Kolbe, Hendrik Wiese, Jonathan Bohren, Nils Berg, cburbridge
```
