### PR TITLE
strands_executive: 0.0.23-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8840,7 +8840,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.22-0
+      version: 0.0.23-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.23-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.22-0`
## gcal_routine

```
* added time window in GCal API query, fixes #194 <https://github.com/strands-project/strands_executive/issues/194>
* Contributors: Marc Hanheide
```
## mdp_plan_exec
- No changes
## scheduler
- No changes
## scipoptsuite
- No changes
## sim_clock
- No changes
## strands_executive_msgs
- No changes
## task_executor

```
* This commit allows execution to recover from non-terminating or slow-to-terminate execution processes (either tasks or navigation).
* Filtering out unexecutable tasks from the routine.
  This has become necessary since the abilty to add daily tasks allows the addition of arbitrary tasks which are no longer bounded sensibly in time by the routine windows.
* Added end time to printout.
* Increased navigation timeout multiplier
  Also added a minimum timeout for all navigation and increased wiggle room on task execution duration.
* remove killer assert
* Moved print statement to after the None check.
  This prevents the error when printint on a None task.
* Fixed task event printer to use default timezone not utc.
* Contributors: Bruno Lacerda, Nick Hawes
```
## wait_action
- No changes
