### PR TITLE
strands_executive_behaviours: 0.0.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8858,7 +8858,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive_behaviours.git
-      version: 0.0.14-0
+      version: 0.0.15-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive_behaviours.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive_behaviours` to `0.0.15-0`:
- upstream repository: https://github.com/strands-project/strands_executive_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_executive_behaviours.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.14-0`
## routine_behaviours

```
* increase force charge threshold to 30 to avoid battery level getting to low
* Contributors: Bruno Lacerda
```
