### PR TITLE
strands_systems: 0.0.11-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8858,7 +8858,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive_behaviours.git
-      version: 0.0.15-0
+      version: 0.0.14-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive_behaviours.git
@@ -9024,7 +9024,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_systems.git
-      version: 0.0.10-0
+      version: 0.0.11-2
   strands_ui:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_systems` to `0.0.11-2`:
- upstream repository: https://github.com/strands-project/strands_systems.git
- release repository: https://github.com/strands-project-releases/strands_systems.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.10-0`
## strands_bringup

```
* using door pass launch
* changing door passing node file name
* Add parameter to disable megnetic barrier.
* Contributors: Bruno Lacerda, Chris Burbridge
```
