### PR TITLE
strands_systems: 0.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9024,7 +9024,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_systems.git
-      version: 0.0.11-2
+      version: 0.0.12-0
   strands_ui:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_systems` to `0.0.12-0`:
- upstream repository: https://github.com/strands-project/strands_systems.git
- release repository: https://github.com/strands-project-releases/strands_systems.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.11-2`
## strands_bringup
- No changes
