### PR TITLE
strands_recovery_behaviours: 0.0.15-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8992,7 +8992,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_recovery_behaviours.git
-      version: 0.0.14-0
+      version: 0.0.15-0
     source:
       type: git
       url: https://github.com/strands-project/strands_recovery_behaviours.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_recovery_behaviours` to `0.0.15-0`:
- upstream repository: https://github.com/strands-project/strands_recovery_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_recovery_behaviours.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.14-0`
## backoff_behaviour
- No changes
## backtrack_behaviour
- No changes
## strands_human_help
- No changes
## strands_monitored_nav_states
- No changes
## strands_recovery_behaviours
- No changes
## walking_group_recovery

```
* Forgot to install the launch file, added now
* Contributors: Nils Bore
```
