### PR TITLE
strands_navigation: 0.0.34-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8933,7 +8933,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.33-0
+      version: 0.0.34-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.34-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.33-0`
## emergency_behaviours
- No changes
## joy_map_saver
- No changes
## message_store_map_switcher
- No changes
## monitored_navigation
- No changes
## nav_goals_generator
- No changes
## pose_initialiser
- No changes
## strands_navigation
- No changes
## strands_navigation_msgs
- No changes
## topological_logging_manager
- No changes
## topological_navigation

```
* Adding boolean to tell topological navigation not to care for orientation in the final node
* fixing bug with repeated edges in prediction, and adding test for this case in test top prediction
* reconfiguring move_base yaw tolerance depending on next action if its move_base type to 2*PI if its none to the default node tolerance and if it is a non move_base type to 30 degrees
* Contributors: Jaime Pulido Fentanes
```
## topological_utils

```
* Oops, that was almost embarrassing.
* Dummy system now sets top map name param.
* fixing insert yaml
* Contributors: Jaime Pulido Fentanes, Nick Hawes
```
