### PR TITLE
strands_executive: 0.0.25-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8884,7 +8884,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.24-0
+      version: 0.0.25-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.25-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.24-0`
## gcal_routine
- No changes
## mdp_plan_exec
- No changes
## scheduler
- No changes
## scipoptsuite
- No changes
## sim_clock
- No changes
## strands_executive_msgs
- No changes
## task_executor

```
* Added defaults for demanded task
* Simple test to check that navigation time is included in executor.
* Made execution schedule aware of navigation time
* Adding testing script of timings including navigation
* Contributors: Nick Hawes
```
## wait_action
- No changes
