### PR TITLE
strands_navigation: 0.0.35-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8973,7 +8973,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.34-0
+      version: 0.0.35-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.35-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.34-0`
## emergency_behaviours
- No changes
## joy_map_saver
- No changes
## message_store_map_switcher
- No changes
## monitored_navigation
- No changes
## nav_goals_generator
- No changes
## pose_initialiser
- No changes
## strands_navigation
- No changes
## strands_navigation_msgs
- No changes
## topological_logging_manager
- No changes
## topological_navigation

```
* forcing the creation of move_base reconfigure client even when there are no move_base edges on the topological map
* sorting nodes by name when calling /topological_map_publisher/get_topological_map service
* Creating Reconfigure Client only for needed actions and handling not available reconfigure clients
* fix for localise by topic where localisation by topic is only verified once the robot has moved more than 10 cm away from the pose it first detected the topic on
* reconfigure using move base on non-move_base type action
* Adding reconfigure Client depending on edge action
* reconfiguring speed and removing move_base to closest node
* Contributors: Jaime Pulido Fentanes
```
## topological_utils
- No changes
