### PR TITLE
strands_hri: 0.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8921,7 +8921,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_hri.git
-      version: 0.0.11-0
+      version: 0.0.12-0
     source:
       type: git
       url: https://github.com/strands-project/strands_hri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_hri` to `0.0.12-0`:
- upstream repository: https://github.com/strands-project/strands_hri.git
- release repository: https://github.com/strands-project-releases/strands_hri.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.11-0`
## bellbot_action_server

```
* Using empty action to start bellbot.
* Contributors: Christian Dondrup
```
## bellbot_gui

```
* removing hardcoded param in bellbot
* Contributors: Jaime Pulido Fentanes
```
## bellbot_scheduler
- No changes
## hrsi_representation
- No changes
## strands_gazing
- No changes
## strands_hri
- No changes
## strands_hri_launch
- No changes
## strands_human_aware_navigation

```
* Adding ability of reconfiguring movebase and human_aware together. Taking new parameters into account in human_aware when resetting speeds.
* Contributors: Christian Dondrup
```
## strands_human_following
- No changes
## strands_interaction_behaviours
- No changes
## strands_simple_follow_me
- No changes
## strands_visualise_speech
- No changes
