### PR TITLE
strands_perception_people: 1.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8999,7 +8999,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 1.1.3-0
+      version: 1.1.4-0
     source:
       type: git
       url: https://github.com/strands-project/strands_perception_people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `1.1.4-0`:
- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.1.3-0`
## bayes_people_tracker
- No changes
## bayes_people_tracker_logging
- No changes
## detector_msg_to_pose_array
- No changes
## ground_plane_estimation
- No changes
## human_trajectory

```
* forgot to add launch folder
* add launch file, add logging_manager permission, add restriction to post trajectories longer than 1 pose.
* add logging manager, fix fluctuating cpu usage
* Contributors: Ferdian Jovan
```
## mdl_people_tracker
- No changes
## odometry_to_motion_matrix
- No changes
## opencv_warco
- No changes
## perception_people_launch
- No changes
## strands_head_orientation
- No changes
## strands_perception_people
- No changes
## upper_body_detector
- No changes
## vision_people_logging
- No changes
## visual_odometry
- No changes
