### PR TITLE
strands_executive: 0.0.26-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8895,7 +8895,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 0.0.25-0
+      version: 0.0.26-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `0.0.26-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.25-0`
## gcal_routine
- No changes
## mdp_plan_exec
- No changes
## scheduler

```
* remove a file which doesnt belong here
* script to get time durations between waypoints
* Contributors: Lenka
```
## scipoptsuite
- No changes
## sim_clock
- No changes
## strands_executive_msgs
- No changes
## task_executor

```
* Fixing the bug with queue/list of unscheduled tasks
* fixing tiny bug in creating list of throwen tasks
* fixed mismatching of tasks numbers
* Fixing that drop method takes into account all tasks(even the previously scheduled)
* Contributors: Lenka
```
## wait_action
- No changes
