### PR TITLE
scitos_common: 0.1.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8272,7 +8272,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_common.git
-      version: 0.1.7-0
+      version: 0.1.8-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_common.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_common` to `0.1.8-0`:
- upstream repository: https://github.com/strands-project/scitos_common.git
- release repository: https://github.com/strands-project-releases/scitos_common.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.7-0`
## scitos_common
- No changes
## scitos_description

```
* Adding respawn flags to scitos_state_publisher.launch
* Contributors: Christian Dondrup
```
## scitos_msgs
- No changes
