### PR TITLE
strands_recovery_behaviours: 0.0.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9042,7 +9042,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_recovery_behaviours.git
-      version: 0.0.15-0
+      version: 0.0.16-0
     source:
       type: git
       url: https://github.com/strands-project/strands_recovery_behaviours.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_recovery_behaviours` to `0.0.16-0`:
- upstream repository: https://github.com/strands-project/strands_recovery_behaviours.git
- release repository: https://github.com/strands-project-releases/strands_recovery_behaviours.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.15-0`
## backoff_behaviour
- No changes
## backtrack_behaviour

```
* Changed to utf8 character encoding and added commas
* Added localization for backtracking and help screens and speech
* Contributors: Nils Bore
```
## strands_human_help

```
* Changed to utf8 character encoding and added commas
* Added localization for backtracking and help screens and speech
* Contributors: Nils Bore
```
## strands_monitored_nav_states
- No changes
## strands_recovery_behaviours
- No changes
## walking_group_recovery
- No changes
