### PR TITLE
scitos_drivers: 0.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8289,7 +8289,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_drivers.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_drivers` to `0.1.6-0`:
- upstream repository: https://github.com/strands-project/scitos_drivers.git
- release repository: https://github.com/strands-project-releases/scitos_drivers.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.5-0`
## flir_pantilt_d46

```
* Adding respawn flags.
* Contributors: Christian Dondrup
```
## scitos_bringup

```
* Adding respawn flags.
* Contributors: Christian Dondrup
```
## scitos_drivers
- No changes
## scitos_mira
- No changes
## scitos_pc_monitor
- No changes
