### PR TITLE
strands_hri: 0.0.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8963,7 +8963,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_hri.git
-      version: 0.0.12-0
+      version: 0.0.13-0
     source:
       type: git
       url: https://github.com/strands-project/strands_hri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_hri` to `0.0.13-0`:
- upstream repository: https://github.com/strands-project/strands_hri.git
- release repository: https://github.com/strands-project-releases/strands_hri.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.12-0`
## bellbot_action_server

```
* more stable transitions, minor GUI fix
* Offering cancel service.
  Publishing setup again.
* Removing unused bellbot functionalities, simplifying state machine. Making state machine preemptable.
* 0.0.12
* updated changelogs
* Offering cancel service.
  Publishing setup again.
* Removing unused bellbot functionalities, simplifying state machine. Making state machine preemptable.
* Using empty action to start bellbot.
* Contributors: Christian Dondrup, Jenkins, Marc Hanheide
```
## bellbot_gui

```
* feedback is stored
* added arrows to setup.html
* minor fixes and more robust behaviour
* feedback working
* added arrows
* more stable transitions, minor GUI fix
* more or less working, with new setup page, and correct pages displayed via topics
* new urls and feebdack page
* 0.0.12
* updated changelogs
* basic navigation skeleton working
* deleted unused files
* new on screen kb that works
* intermediate checkin
* removing hardcoded param in bellbot
* new stuff
* removed obsolete
* copied content
* moved old files to static
* Contributors: Jaime Pulido Fentanes, Jenkins, Marc Hanheide
```
## bellbot_scheduler

```
* 0.0.12
* updated changelogs
* Contributors: Jenkins
```
## hrsi_representation

```
* Merge pull request #112 <https://github.com/strands-project/strands_hri/issues/112> from cdondrup/qsrs_for
  [hrsi_representation] Using 'qsrs_for' to prevent redundancy.
* 0.0.12
* updated changelogs
* Using 'qsrs_for' to prevent redundancy.
* Handling new string representation of qtc
* Contributors: Christian Dondrup, Jenkins
```
## strands_gazing

```
* 0.0.12
* updated changelogs
* Contributors: Jenkins
```
## strands_hri

```
* 0.0.12
* updated changelogs
* Contributors: Jenkins
```
## strands_hri_launch

```
* 0.0.12
* updated changelogs
* Contributors: Jenkins
```
## strands_human_aware_navigation

```
* Exposing human_aware_navigation params via launch file.
* 0.0.12
* updated changelogs
* Contributors: Christian Dondrup, Jenkins
```
## strands_human_following

```
* 0.0.12
* updated changelogs
* Contributors: Jenkins
```
## strands_interaction_behaviours

```
* 0.0.12
* updated changelogs
* Contributors: Jenkins
```
## strands_simple_follow_me

```
* 0.0.12
* updated changelogs
* Contributors: Jenkins
```
## strands_visualise_speech

```
* 0.0.12
* updated changelogs
* Contributors: Jenkins
```
