### PR TITLE
strands_navigation: 0.0.36-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9015,7 +9015,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.35-0
+      version: 0.0.36-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.36-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.35-0`
## emergency_behaviours

```
* Ok, I managed to mess this up :/ this is the tested and working version on Linda
* cancelling navigation goals on emergencies and making email addresses configurable
* implementing safety stop at current node
* setting server address for strands emails on henry
* changing free run policy on emergency behaviours
* Contributors: Jailander, Jaime Pulido Fentanes
```
## joy_map_saver
- No changes
## message_store_map_switcher
- No changes
## monitored_navigation
- No changes
## nav_goals_generator
- No changes
## pose_initialiser
- No changes
## strands_navigation
- No changes
## strands_navigation_msgs
- No changes
## topological_logging_manager

```
* Don't accept substrings for logging manager
  Closes #250 <https://github.com/strands-project/strands_navigation/issues/250>
  Tested in simulation.
* Contributors: Christian Dondrup
```
## topological_navigation

```
* Added the wait_reset_bumper_duration to top_nav.launch
* if localised by topic assume as current node no matter pose
* removing speed reconfiguration in topological navigation, this is messing with the walking group speeds, there should be something smarter like in policy execution
* Contributors: Jaime Pulido Fentanes, Nils Bore
```
## topological_utils
- No changes
