### PR TITLE
scitos_apps: 0.0.20-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -8326,7 +8326,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_apps.git
-      version: 0.0.19-0
+      version: 0.0.20-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_apps` to `0.0.20-0`:
- upstream repository: https://github.com/strands-project/scitos_apps.git
- release repository: https://github.com/strands-project-releases/scitos_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.19-0`
## ptu_follow_frame
- No changes
## scitos_apps
- No changes
## scitos_cmd_vel_mux
- No changes
## scitos_dashboard
- No changes
## scitos_docking

```
* Merge branch 'hydro-devel' of https://github.com/strands-project/scitos_apps into dyn_subscription
* keep subscribed to most topics
* Contributors: Marc Hanheide
```
## scitos_ptu
- No changes
## scitos_teleop
- No changes
## scitos_touch
- No changes
