### PR TITLE
openni_wrapper: 0.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5431,7 +5431,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/openni_wrapper.git
-      version: 0.0.10-5
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/strands-project/openni_wrapper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `openni_wrapper` to `0.0.11-0`:
- upstream repository: https://github.com/strands-project/openni_wrapper.git
- release repository: https://github.com/strands-project-releases/openni_wrapper.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.10-5`
## openni_wrapper
- No changes
