### PR TITLE
strands_apps: 0.1.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9094,10 +9094,11 @@ repositories:
       - strands_apps
       - strands_emails
       - topic_republisher
+      - watchdog_node
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_apps.git
-      version: 0.1.9-0
+      version: 0.1.10-0
     source:
       type: git
       url: https://github.com/strands-project/strands_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.1.10-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.9-0`
## watchdog_node

```
* Fix renamed install target.
* Rename package to watchdog_node.
* Contributors: Chris Burbridge
```
