### PR TITLE
strands_qsr_lib: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9286,7 +9286,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_qsr_lib.git
-      version: 0.0.8-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/strands-project/strands_qsr_lib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_qsr_lib` to `0.1.0-0`:
- upstream repository: https://github.com/strands-project/strands_qsr_lib.git
- release repository: https://github.com/strands-project-releases/strands_qsr_lib.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.8-0`
## qsr_lib

```
* fix mos in example
* Getting rid of parameters namespace inside of dynamic_args.
* Merge branch 'master' into qtc_params
  Conflicts:
  qsr_lib/scripts/example_ros_client.py
* Moved qtc parameters to service call
  Using dynamic_args and the newly created field 'parameters'.
  Should be fully backwards compatible with the option of removing this later on.
* Example client bug fix
  The mos test broke all the other QSR which don't define q.
  Commented it and using the more generic service call now.
* qsr MOS (moving or stationary)
* Merge pull request #59 <https://github.com/strands-project/strands_qsr_lib/issues/59> from yianni/58
  cone_direction now complies with --future (closes #58 <https://github.com/strands-project/strands_qsr_lib/issues/58>)
* Merge pull request #60 <https://github.com/strands-project/strands_qsr_lib/issues/60> from yianni/qtc-future
  qtc compliant with future, closes #50 <https://github.com/strands-project/strands_qsr_lib/issues/50>
* Merge pull request #56 <https://github.com/strands-project/strands_qsr_lib/issues/56> from yianni/change-ini
  changed config files from ini format to yaml
* qtc compliant with future, closes #50 <https://github.com/strands-project/strands_qsr_lib/issues/50>
* --amend
* updated shortcut for coneDir
* cone_direction now complies with --future (closes #58 <https://github.com/strands-project/strands_qsr_lib/issues/58>)
* shortened return string
* providing example of config format for arg_relations_distance
* changed config files from ini format to yaml
* add_object_track_from_list propagates **kwargs to Object_State
* added funtionality to add an object's track from a list of values
* Contributors: Christian Dondrup, Peter Lightbody, Yiannis Gatsoulis
```
## strands_qsr_lib
- No changes
