### PR TITLE
strands_morse: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9277,7 +9277,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.0.24-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.1.0-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.24-0`
## strands_morse

```
* Merge pull request #131 <https://github.com/strands-project/strands_morse/issues/131> from Jailander/aachen
  AAChen simulation
* fixes in blender file
* adding topological map
* AAChen simulation
* Merge pull request #130 <https://github.com/strands-project/strands_morse/issues/130> from jayyoung/indigo-devel
  ALOOF: Robot staring at a populated table
* ALOOF: Robot staring at a populated table
* Contributors: Jaime Pulido Fentanes, Marc Hanheide, Nick Hawes, jay
```
