### PR TITLE
strands_morse: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9466,7 +9466,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.1.2-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.1-0`
## strands_morse

```
* Merge pull request #133 <https://github.com/strands-project/strands_morse/issues/133> from cdondrup/move_human
  Adding movement controller to human for UOL_MHT enviroment
* Adding static transform publisher from map to world for human position transformation.
* Adding movement controller to human. Now accepts cmd_vels.
* Contributors: Christian Dondrup, Marc Hanheide
```
