### PR TITLE
strands_qsr_lib: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9693,11 +9693,12 @@ repositories:
     release:
       packages:
       - qsr_lib
+      - qsr_prob_rep
       - strands_qsr_lib
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_qsr_lib.git
-      version: 0.1.1-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/strands-project/strands_qsr_lib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_qsr_lib` to `0.1.2-0`:
- upstream repository: https://github.com/strands-project/strands_qsr_lib.git
- release repository: https://github.com/strands-project-releases/strands_qsr_lib.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.1-0`
## qsr_prob_rep

```
* Adding RCC3 as an easy example on how to add new QSRs to the prob rep lib.
  Also, updating README.
* Removing rubbish from test file.
* Updated documentation to reflect name changes.
* Cleaning up cmake and package file, adding qsr_prob_rep to meta package
* Adding tests for creation, sampling and loglikelihood of all three qtc types.
* Finally enabling qtcbc and minor changes
  * qtcbc now works using code from qtcb and qtcc and some custom functions overwriting the ones in qtc_hmm_abstractclass
  * Removed some prints and fixed comments.
* Fixing a bug where the final state was always 82... d'oh
* Renaming package
* Contributors: Christian Dondrup
```
