### PR TITLE
strands_qsr_lib: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9698,7 +9698,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_qsr_lib.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/strands-project/strands_qsr_lib.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_qsr_lib` to `0.1.3-0`:
- upstream repository: https://github.com/strands-project/strands_qsr_lib.git
- release repository: https://github.com/strands-project-releases/strands_qsr_lib.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.2-0`
## qsr_lib

```
* Adding test for non collapsed QTC.
* example_ros_client cleanup
* resolves a bug introduced in #95 <https://github.com/strands-project/strands_qsr_lib/issues/95>, #88 <https://github.com/strands-project/strands_qsr_lib/issues/88>
* Contributors: Christian Dondrup, Yiannis Gatsoulis
```
## qsr_prob_rep
- No changes
## strands_qsr_lib
- No changes
