### PR TITLE
strands_3d_mapping: 0.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9525,10 +9525,28 @@ repositories:
       url: https://github.com/wunderkammer-laboratory/steered_wheel_base_controller.git
       version: master
   strands_3d_mapping:
+    release:
+      packages:
+      - calibrate_sweeps
+      - cloud_merge
+      - ekz_public_lib
+      - metaroom_xml_parser
+      - object_manager
+      - scitos_ptu_sweep
+      - semantic_map
+      - semantic_map_launcher
+      - semantic_map_publisher
+      - semantic_map_to_2d
+      - strands_sweep_registration
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/strands_3d_mapping.git
+      version: 0.0.10-0
     source:
       type: git
       url: https://github.com/strands-project/strands_3d_mapping.git
       version: hydro-devel
+    status: developed
   strands_apps:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_3d_mapping` to `0.0.10-0`:
- upstream repository: https://github.com/strands-project/strands_3d_mapping.git
- release repository: https://github.com/strands-project-releases/strands_3d_mapping.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## calibrate_sweeps

```
* updated changelogs
* Fixed sweep registration bug
* Fixed typo
* message generation dependency
* Updating packages with new include paths
* Package renaming
* Updated dependencies for calibrate_sweeps package
* Transforming to the map frame of reference after rebuilding clouds
* bugfix
* Fixed CMakeLists.txt
* Adding calibrate sweeps action server as a separate package
* Contributors: Marc Hanheide, Rares, Rares Ambrus
* Fixed sweep registration bug
* Fixed typo
* message generation dependency
* Updating packages with new include paths
* Package renaming
* Updated dependencies for calibrate_sweeps package
* Transforming to the map frame of reference after rebuilding clouds
* bugfix
* Fixed CMakeLists.txt
* Adding calibrate sweeps action server as a separate package
* Contributors: Rares, Rares Ambrus
* Fixed sweep registration bug
* Fixed typo
* message generation dependency
* Updating packages with new include paths
* Package renaming
* Updated dependencies for calibrate_sweeps package
* Transforming to the map frame of reference after rebuilding clouds
* bugfix
* Fixed CMakeLists.txt
* Adding calibrate sweeps action server as a separate package
* Contributors: Rares, Rares Ambrus
```
## cloud_merge

```
* updated changelogs
* Updated dependencies for cloud_merge package
* merge from hydro-devel
* bugfix
* Loading camera params from file
* Computing ORB features
* Register individual sweep clouds using precomputed sweep poses
* Added parameters for loading precalibrated sweep poses
* Changed launch file parameters to disable logging the intermediate clouds to the datacenter. Also enabled updating the metaroom with new observations
* Moved mongodb_interface class to the semantic_map package. Updated corresponding include files
* SemanticMapSummaryParser no longer templated (not required). Some methods are still templated, todo remove the templates by avoiding instantiating objects of type MetaRoom or SemanticRoom (which are templated)
* Added explicit template instantiation for cloud_merge package
* More informative print statement
* save_intermediate_images parameter defaults to false
* Renamed save_intermediate parameter to save_intermediate_clouds
* Added save_intermediate_images parameter to the launch file
* Saving intermediate images default value false
* Since we are using images no need to wait for the TF to reflect the PTU movement
* Bugfix - rgb camera info message
* Bugfix - loading proper cam info parameters for intermediate depth images
* bugfix cam info topic
* Added launch file parameters for depth and rgb camera parameter topics
* When saving intermediate images: added transforms for both depth and rgb cameras as well as camera parameters for each intermediate position
* Added one more input camera info topic for the depth camera
* Added debug message when saving intermediate images
* Added empty readme file
* Retrieving intermediate cloud images and adding them to the new room
* Contributors: Marc Hanheide, Rares, Rares Ambrus, RaresAmbrus
* Updated dependencies for cloud_merge package
* merge from hydro-devel
* bugfix
* Loading camera params from file
* Computing ORB features
* Register individual sweep clouds using precomputed sweep poses
* Added parameters for loading precalibrated sweep poses
* Changed launch file parameters to disable logging the intermediate clouds to the datacenter. Also enabled updating the metaroom with new observations
* Moved mongodb_interface class to the semantic_map package. Updated corresponding include files
* SemanticMapSummaryParser no longer templated (not required). Some methods are still templated, todo remove the templates by avoiding instantiating objects of type MetaRoom or SemanticRoom (which are templated)
* Added explicit template instantiation for cloud_merge package
* More informative print statement
* save_intermediate_images parameter defaults to false
* Renamed save_intermediate parameter to save_intermediate_clouds
* Added save_intermediate_images parameter to the launch file
* Saving intermediate images default value false
* Since we are using images no need to wait for the TF to reflect the PTU movement
* Bugfix - rgb camera info message
* Bugfix - loading proper cam info parameters for intermediate depth images
* bugfix cam info topic
* Added launch file parameters for depth and rgb camera parameter topics
* When saving intermediate images: added transforms for both depth and rgb cameras as well as camera parameters for each intermediate position
* Added one more input camera info topic for the depth camera
* Added debug message when saving intermediate images
* Added empty readme file
* Retrieving intermediate cloud images and adding them to the new room
* Contributors: Rares, Rares Ambrus, RaresAmbrus
```
## ekz_public_lib

```
* updated changelogs
* Fixed pcl dependency and removed g2o
* Removed opencv2 dependency
* Removing opencv nonfree stuff
* Contributors: Marc Hanheide, Rares Ambrus
* Fixed pcl dependency and removed g2o
* Removed opencv2 dependency
* Removing opencv nonfree stuff
* Contributors: Rares Ambrus
```
## metaroom_xml_parser

```
* updated changelogs
* Removed debug print
* Added methods to load labelled data & example program
* Added flag to indicate whether to load intermediate cloud (useful when looking only for the transform)
* Fixed sweep sort (taking date into account
* Sorting sweeps based on patrol number and room number
* Also logging room run number (useful for reading objects  from mongo and saving them in the proper folder structure on the disk)
* Returning the room log start time as part of the sweep structure
* Returning the room log name as part of the sweep structure
* Cleanup
* debug statement cleanup
* bigfix
* Load orb features
* Minor changes
* Fixed include guard
* Simple xml parser now reads corrected camera parameters and registered tranforms as well
* Bugfix in loading all dynamic clusters at a particular waypoint
* Bugfixes
* Methods to parse and return dynamic cluster point clouds
* SimpleXmlParser now parses and returns the dynamic clusters clouds, if it's been saved
* utilities to get all the sweep xmls in a folder or for a particular waypoint
* Removed debug prints
* Safeguard against corrupted xmls
* Removed test utilities main file
* Simple summary parser now checks that found sweep xml files start with the correct element
* Simple summary parser now parses any folder structure looking for sweep xml files (not just the semantic map standard folder structure - date/patrol_run_#/room_#/room.xml)
* Added load_utilities.hpp and moved function implementations out of load_utilities.h
* Commented out visualization of intermediate position images after parsing
* Added routines for parsing intermediate sweep clouds and intermediate position images
* Added / at the end of the folder path (more robust this way)
* Added a vector of xml nodes that are to be parsed - this allows to load only particular fields (and thus point clouds or images) for sweeps. The fields covered are RoomCompleteCloud, RoomIntermediateCloud and IntermediatePosition
* utilities to load all the merged point clouds from sweeps saved in some particular folder, and to load all the merged clouds for all the sweeps taken at some waypoint
* Method to load the merged point cloud from a single sweep
* Added verbose flag to the simple xml parser (default value false)
* Removed unnecessary comments
* Added load_utilities files - will contain higher level functions which will allow parsing local metric maps and returning various components
* Renaming
* Added explicit template instantiation for metaroom_xml_parser package
* SimpleSummaryParser no longer templated
* Bugfix
* Printing intermediate image parameters
* Loading intermediate room images, transforms and parameters
* Contributors: Marc Hanheide, Rares, Rares Ambrus
* Removed debug print
* Added methods to load labelled data & example program
* Added flag to indicate whether to load intermediate cloud (useful when looking only for the transform)
* Fixed sweep sort (taking date into account
* Sorting sweeps based on patrol number and room number
* Also logging room run number (useful for reading objects  from mongo and saving them in the proper folder structure on the disk)
* Returning the room log start time as part of the sweep structure
* Returning the room log name as part of the sweep structure
* Cleanup
* debug statement cleanup
* bigfix
* Load orb features
* Minor changes
* Fixed include guard
* Simple xml parser now reads corrected camera parameters and registered tranforms as well
* Bugfix in loading all dynamic clusters at a particular waypoint
* Bugfixes
* Methods to parse and return dynamic cluster point clouds
* SimpleXmlParser now parses and returns the dynamic clusters clouds, if it's been saved
* utilities to get all the sweep xmls in a folder or for a particular waypoint
* Removed debug prints
* Safeguard against corrupted xmls
* Removed test utilities main file
* Simple summary parser now checks that found sweep xml files start with the correct element
* Simple summary parser now parses any folder structure looking for sweep xml files (not just the semantic map standard folder structure - date/patrol_run_#/room_#/room.xml)
* Added load_utilities.hpp and moved function implementations out of load_utilities.h
* Commented out visualization of intermediate position images after parsing
* Added routines for parsing intermediate sweep clouds and intermediate position images
* Added / at the end of the folder path (more robust this way)
* Added a vector of xml nodes that are to be parsed - this allows to load only particular fields (and thus point clouds or images) for sweeps. The fields covered are RoomCompleteCloud, RoomIntermediateCloud and IntermediatePosition
* utilities to load all the merged point clouds from sweeps saved in some particular folder, and to load all the merged clouds for all the sweeps taken at some waypoint
* Method to load the merged point cloud from a single sweep
* Added verbose flag to the simple xml parser (default value false)
* Removed unnecessary comments
* Added load_utilities files - will contain higher level functions which will allow parsing local metric maps and returning various components
* Renaming
* Added explicit template instantiation for metaroom_xml_parser package
* SimpleSummaryParser no longer templated
* Bugfix
* Printing intermediate image parameters
* Loading intermediate room images, transforms and parameters
* Contributors: Rares, Rares Ambrus
```
## object_manager

```
* updated changelogs
* debug print
* Added object manager library as CMake target
* Safety copy
* Bugfix - saving additional view
* Logging the transform from the camera frame of ref to the map frame of ref for the additional view point clouds
* Logging and loading objects tracks from mongodb
* Added saving and loading of dynamic object tracks
* Added DynamicObjectTracks message
* Testing of saving/loading/logging additional views for dynamic objects
* Subscribing to the object views topic and adding views to dynamic objects
* Logging/reading additional views to/from mongodb
* Additional views and saving/loading from disk
* Service calls always return true
* Removed unnecessary compilation of classes
* Logging objects to the database parameter
* Node to export dynamic elements out of mongodb
* Removing debug cv window
* Also logging room run number (useful for reading objects  from mongo and saving them in the proper folder structure on the disk)
* Saving dynamic objects in mongodb
* Dynamic object utilities
* Saving and loading dynamic objects on the disk
* added dynamic_object_xml_parser class
* added dynami_object class
* Added dynamic_object files and openmp dependency
* Install targets
* Updated dependencies for object_manager package
* Removed debug cv window
* Returning pan and tilt PTU angles in the service message
* Get object service
* Mask extraction
* Added centroids
* Filtering ground points
* Added object manager class
* Contributors: Marc Hanheide, Rares, Rares Ambrus
* debug print
* Added object manager library as CMake target
* Safety copy
* Bugfix - saving additional view
* Logging the transform from the camera frame of ref to the map frame of ref for the additional view point clouds
* Logging and loading objects tracks from mongodb
* Added saving and loading of dynamic object tracks
* Added DynamicObjectTracks message
* Testing of saving/loading/logging additional views for dynamic objects
* Subscribing to the object views topic and adding views to dynamic objects
* Logging/reading additional views to/from mongodb
* Additional views and saving/loading from disk
* Service calls always return true
* Removed unnecessary compilation of classes
* Logging objects to the database parameter
* Node to export dynamic elements out of mongodb
* Removing debug cv window
* Also logging room run number (useful for reading objects  from mongo and saving them in the proper folder structure on the disk)
* Saving dynamic objects in mongodb
* Dynamic object utilities
* Saving and loading dynamic objects on the disk
* added dynamic_object_xml_parser class
* added dynami_object class
* Added dynamic_object files and openmp dependency
* Install targets
* Updated dependencies for object_manager package
* Removed debug cv window
* Returning pan and tilt PTU angles in the service message
* Get object service
* Mask extraction
* Added centroids
* Filtering ground points
* Added object manager class
* Contributors: Rares, Rares Ambrus
* debug print
* Added object manager library as CMake target
* Safety copy
* Bugfix - saving additional view
* Logging the transform from the camera frame of ref to the map frame of ref for the additional view point clouds
* Logging and loading objects tracks from mongodb
* Added saving and loading of dynamic object tracks
* Added DynamicObjectTracks message
* Testing of saving/loading/logging additional views for dynamic objects
* Subscribing to the object views topic and adding views to dynamic objects
* Logging/reading additional views to/from mongodb
* Additional views and saving/loading from disk
* Service calls always return true
* Removed unnecessary compilation of classes
* Logging objects to the database parameter
* Node to export dynamic elements out of mongodb
* Removing debug cv window
* Also logging room run number (useful for reading objects  from mongo and saving them in the proper folder structure on the disk)
* Saving dynamic objects in mongodb
* Dynamic object utilities
* Saving and loading dynamic objects on the disk
* added dynamic_object_xml_parser class
* added dynami_object class
* Added dynamic_object files and openmp dependency
* Install targets
* Updated dependencies for object_manager package
* Removed debug cv window
* Returning pan and tilt PTU angles in the service message
* Get object service
* Mask extraction
* Added centroids
* Filtering ground points
* Added object manager class
* Contributors: Rares, Rares Ambrus
```
## scitos_ptu_sweep

```
* updated changelogs
* Contributors: Marc Hanheide
```
## semantic_map

```
* updated changelogs
* Fixed return statement to get rid of warning
* Updated debug statement
* Fixed memory management bug; changed to use shared pointer; fixed parameter bug
* Using shared pointers
* Returning shared pointers and not objects; less memory management hassles
* Checking sweep match by waypoint ID and fixed bug in sweep saving
* Changed default parameter for saving metaroom steps to false
* updated sweep add task script with better parameters
* Added a launch file argument to switch between NDT registration and image feature registration for registering sweeps. Default is NDT
* Added service to clear and reinitialize the metarooms at specific (or all) waypoints
* Older sweeps moved to cache by checking waypoint id
* Find matching metaroom by waypoint id instead of centroid distance
* Publishing status message once an observation has been processed
* Fixed typo in package name
* Added support for getting only the latest dynamic clusters
* separate function for updating room with metaroom
* Bugfix when setting the room transform after registration
* Updating packages with new include paths
* Package renaming
* Updated dependencies for semantic_map package
* Removed debug prints
* merge from hydro-devel
* cleanup
* Minor code cleanup
* Enabled feature based registration between sweeps
* Adding methods to convert from the intermediate cloud to the pan and tilt PTU angles
* Added saving and loading of sweep parameters in the xml
* Fixed bug in finding the corresponding metaroom based on waypoint id
* Fixed semantic_map_node crash if supplied xml file is invalid
* Creating and updating metaroom using new registration
* debug print
* Sweep ORB registration
* Saving ORB features for metarooms
* Saving camera parameters after registration
* Bugfix for the case when a sweep xml file cannot be parsed
* removed services
* debug statement cleanup
* Bugfix
* Saving raw registration data
* new class
* Include guards
* utilities for manipulation sweeps
* Bugfix
* New classes & fixed exporting the library
* Computing orb features from intermediate images making up a sweep and saving them to disk
* Added registered transforms save/load routine
* Minor changes
* Added a method to clear the intermediate corrected camera parameters
* Room registration before updating metaroom now optional
* Removed debug statement
* Now storing corrected camera parameters for each intermediate point cloud (useful for correction)
* Changed the interior cloud size to 0.02m (from 0.01m). More robust to noise
* Lowered the max dynamic cluster size
* Changed launch file parameters to disable logging the intermediate clouds to the datacenter. Also enabled updating the metaroom with new observations
* Not updating the metaroom with an observation when having to remove/add too many points
* Fixed ndt registration bug
* Changed returned type of updateMetaRoom to make it easier to see the changes
* Point based way of checking for occlusions
* Added optional parameter specifying where to save room after using it to update metaroom
* Adding executable that parses a metric map folder structure and adds all the saved sweeps to mongodb
* Moved mongodb_interface class to the semantic_map package. Updated corresponding include files
* Checking that we actually got a point cloud from mongodb; useful if inserting the point returned failure (e.g. due to file size) but we would still look for it in the database
* Removed debug statements
* Clearing the intermediate registered transforms vector (useful when re-registering a sweep)
* Setting the root folder from a room xml file
* Saving and load intermediate registered transform
* Added registered transform
* Forward declarations
* SemanticMapSummaryParser no longer templated (not required). Some methods are still templated, todo remove the templates by avoiding instantiating objects of type MetaRoom or SemanticRoom (which are templated)
* Added roombase.hpp and moved implementation out of the header file
* Added semantic_map_node to CMakeLists
* Added metaroom_xml_parser.hpp and moved implementation out of the header file
* Added metaroom.hpp and moved implementation out of the header file
* Added metaroom_update_iteration class and moved definition and implementation from the metaroom class header
* Added room_xml_parser.hpp and moved implementation out of the header file
* Added room.hpp and moved implementation out of the header file
* Added explicit template instantiation for semantic_map package
* Fixed compilation dependency on messages generated by semantic_map
* Merge remote-tracking branch 'upstream/hydro-devel' into log_images
  Conflicts:
  cloud_merge/include/cloud_merge_node.h
* Bugfix - incrementing the intermediate images position counter
* Loading intermediate room images from disk
* Loading camera parameters and transforms for intermediate room imageS
* Bugfix - rgb camera info message
* Bugfix - adding intermediate images
* Saving intermediate position images into the room xml file
* When saving intermediate images: added transforms for both depth and rgb cameras as well as camera parameters for each intermediate position
* debugging
* Added debug message when saving intermediate images
* Merge remote-tracking branch 'upstream/hydro-devel' into log_images
* Storing individual images and saving them to disk
* Added cv_bridge dependency (for converting between sensor_msgs/Image and cv::Mat)
* Contributors: Marc Hanheide, Rares, Rares Ambrus, RaresAmbrus, rares
* Fixed return statement to get rid of warning
* Updated debug statement
* Fixed memory management bug; changed to use shared pointer; fixed parameter bug
* Using shared pointers
* Returning shared pointers and not objects; less memory management hassles
* Checking sweep match by waypoint ID and fixed bug in sweep saving
* Changed default parameter for saving metaroom steps to false
* updated sweep add task script with better parameters
* Added a launch file argument to switch between NDT registration and image feature registration for registering sweeps. Default is NDT
* Added service to clear and reinitialize the metarooms at specific (or all) waypoints
* Older sweeps moved to cache by checking waypoint id
* Find matching metaroom by waypoint id instead of centroid distance
* Publishing status message once an observation has been processed
* Fixed typo in package name
* Added support for getting only the latest dynamic clusters
* separate function for updating room with metaroom
* Bugfix when setting the room transform after registration
* Updating packages with new include paths
* Package renaming
* Updated dependencies for semantic_map package
* Removed debug prints
* merge from hydro-devel
* cleanup
* Minor code cleanup
* Enabled feature based registration between sweeps
* Adding methods to convert from the intermediate cloud to the pan and tilt PTU angles
* Added saving and loading of sweep parameters in the xml
* Fixed bug in finding the corresponding metaroom based on waypoint id
* Fixed semantic_map_node crash if supplied xml file is invalid
* Creating and updating metaroom using new registration
* debug print
* Sweep ORB registration
* Saving ORB features for metarooms
* Saving camera parameters after registration
* Bugfix for the case when a sweep xml file cannot be parsed
* removed services
* debug statement cleanup
* Bugfix
* Saving raw registration data
* new class
* Include guards
* utilities for manipulation sweeps
* Bugfix
* New classes & fixed exporting the library
* Computing orb features from intermediate images making up a sweep and saving them to disk
* Added registered transforms save/load routine
* Minor changes
* Added a method to clear the intermediate corrected camera parameters
* Room registration before updating metaroom now optional
* Removed debug statement
* Now storing corrected camera parameters for each intermediate point cloud (useful for correction)
* Changed the interior cloud size to 0.02m (from 0.01m). More robust to noise
* Lowered the max dynamic cluster size
* Changed launch file parameters to disable logging the intermediate clouds to the datacenter. Also enabled updating the metaroom with new observations
* Not updating the metaroom with an observation when having to remove/add too many points
* Fixed ndt registration bug
* Changed returned type of updateMetaRoom to make it easier to see the changes
* Point based way of checking for occlusions
* Added optional parameter specifying where to save room after using it to update metaroom
* Adding executable that parses a metric map folder structure and adds all the saved sweeps to mongodb
* Moved mongodb_interface class to the semantic_map package. Updated corresponding include files
* Checking that we actually got a point cloud from mongodb; useful if inserting the point returned failure (e.g. due to file size) but we would still look for it in the database
* Removed debug statements
* Clearing the intermediate registered transforms vector (useful when re-registering a sweep)
* Setting the root folder from a room xml file
* Saving and load intermediate registered transform
* Added registered transform
* Forward declarations
* SemanticMapSummaryParser no longer templated (not required). Some methods are still templated, todo remove the templates by avoiding instantiating objects of type MetaRoom or SemanticRoom (which are templated)
* Added roombase.hpp and moved implementation out of the header file
* Added semantic_map_node to CMakeLists
* Added metaroom_xml_parser.hpp and moved implementation out of the header file
* Added metaroom.hpp and moved implementation out of the header file
* Added metaroom_update_iteration class and moved definition and implementation from the metaroom class header
* Added room_xml_parser.hpp and moved implementation out of the header file
* Added room.hpp and moved implementation out of the header file
* Added explicit template instantiation for semantic_map package
* Fixed compilation dependency on messages generated by semantic_map
* Merge remote-tracking branch 'upstream/hydro-devel' into log_images
  Conflicts:
  cloud_merge/include/cloud_merge_node.h
* Bugfix - incrementing the intermediate images position counter
* Loading intermediate room images from disk
* Loading camera parameters and transforms for intermediate room imageS
* Bugfix - rgb camera info message
* Bugfix - adding intermediate images
* Saving intermediate position images into the room xml file
* When saving intermediate images: added transforms for both depth and rgb cameras as well as camera parameters for each intermediate position
* debugging
* Added debug message when saving intermediate images
* Merge remote-tracking branch 'upstream/hydro-devel' into log_images
* Storing individual images and saving them to disk
* Added cv_bridge dependency (for converting between sensor_msgs/Image and cv::Mat)
* Contributors: Rares, Rares Ambrus, RaresAmbrus, rares
```
## semantic_map_launcher

```
* updated changelogs
* Added a launch file argument to switch between NDT registration and image feature registration for registering sweeps. Default is NDT
* Logging the sweeps to mongodb enabled by default
* Added support for getting only the latest dynamic clusters
* separate function for updating room with metaroom
* Logging objects to the database parameter
* Added semantic_map_launcher packager (just a launch file with all the mapping nodes)
* Contributors: Marc Hanheide, Rares, Rares Ambrus
* Added a launch file argument to switch between NDT registration and image feature registration for registering sweeps. Default is NDT
* Logging the sweeps to mongodb enabled by default
* Added support for getting only the latest dynamic clusters
* separate function for updating room with metaroom
* Logging objects to the database parameter
* Added semantic_map_launcher packager (just a launch file with all the mapping nodes)
* Contributors: Rares, Rares Ambrus
* Added a launch file argument to switch between NDT registration and image feature registration for registering sweeps. Default is NDT
* Logging the sweeps to mongodb enabled by default
* Added support for getting only the latest dynamic clusters
* separate function for updating room with metaroom
* Logging objects to the database parameter
* Added semantic_map_launcher packager (just a launch file with all the mapping nodes)
* Contributors: Rares, Rares Ambrus
```
## semantic_map_publisher

```
* updated changelogs
* Added WaypointTimestampService ObservationInstanceService and ObservationOctomapInstanceService
* Added sensor origin service
* Service calls always return true
* Generate messages dependency
* Package renaming
* Updated dependencies for semantic_map_publisher package
* Removing dynamic cluster service
* Error checking
* Removed debug map saving
* Added new publisher node
* Contributors: Marc Hanheide, Rares, Rares Ambrus
* Added WaypointTimestampService ObservationInstanceService and ObservationOctomapInstanceService
* Added sensor origin service
* Service calls always return true
* Generate messages dependency
* Package renaming
* Updated dependencies for semantic_map_publisher package
* Removing dynamic cluster service
* Error checking
* Removed debug map saving
* Added new publisher node
* Contributors: Rares, Rares Ambrus
* Added WaypointTimestampService ObservationInstanceService and ObservationOctomapInstanceService
* Added sensor origin service
* Service calls always return true
* Generate messages dependency
* Package renaming
* Updated dependencies for semantic_map_publisher package
* Removing dynamic cluster service
* Error checking
* Removed debug map saving
* Added new publisher node
* Contributors: Rares, Rares Ambrus
```
## semantic_map_to_2d

```
* updated changelogs
* Remove bad install target.
* Add depend on semantic_map_publisher.
* Add depend on semantic_map_publisher.
* Fix gencpp dependency.
* Add node to publish 2d map of waypoint sweeps.
* Contributors: Chris Burbridge, Marc Hanheide
* Remove bad install target.
* Add depend on semantic_map_publisher.
* Add depend on semantic_map_publisher.
* Fix gencpp dependency.
* Add node to publish 2d map of waypoint sweeps.
* Contributors: Chris Burbridge
* Remove bad install target.
* Add depend on semantic_map_publisher.
* Add depend on semantic_map_publisher.
* Fix gencpp dependency.
* Add node to publish 2d map of waypoint sweeps.
* Contributors: Chris Burbridge
```
## strands_sweep_registration

```
* updated changelogs
* Added ceres and suitesparse libraries in package.xml
* Fixed pcl dependency and removed g2o
* Restructuring package to follow ros naming conventions
* Package renaming
* Contributors: Marc Hanheide, Rares Ambrus
* Added ceres and suitesparse libraries in package.xml
* Fixed pcl dependency and removed g2o
* Restructuring package to follow ros naming conventions
* Package renaming
* Contributors: Rares Ambrus
* Added ceres and suitesparse libraries in package.xml
* Fixed pcl dependency and removed g2o
* Restructuring package to follow ros naming conventions
* Package renaming
* Contributors: Rares Ambrus
```
