### PR TITLE
data_compression: 0.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1541,7 +1541,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/data_compression.git
-      version: 0.0.9-0
+      version: 0.0.10-0
     source:
       type: git
       url: https://github.com/strands-project/data_compression.git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_compression` to `0.0.10-0`:
- upstream repository: https://github.com/strands-project/data_compression.git
- release repository: https://github.com/strands-project-releases/data_compression.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.9-0`
## catkinized_libav

```
* After some hackery this works again for both devel and install builds
* Contributors: Nils Bore
```
## libav_image_transport
- No changes
## mongodb_openni_compression
- No changes
## rosbag_openni_compression

```
* Calling the correct node
* Renamed action
* Fixed typo
* Added action server for starting/stopping recording of camera topics to a rosbag
* Contributors: Rares Ambrus
```
