### PR TITLE
strands_3d_mapping: 0.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9597,7 +9597,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_3d_mapping.git
-      version: 0.0.10-0
+      version: 0.0.12-0
     source:
       type: git
       url: https://github.com/strands-project/strands_3d_mapping.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_3d_mapping` to `0.0.12-0`:
- upstream repository: https://github.com/strands-project/strands_3d_mapping.git
- release repository: https://github.com/strands-project-releases/strands_3d_mapping.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.10-0`
## calibrate_sweeps
- No changes
## cloud_merge
- No changes
## ekz_public_lib
- No changes
## metaroom_xml_parser
- No changes
## object_manager
- No changes
## scitos_ptu_sweep
- No changes
## semantic_map
- No changes
## semantic_map_launcher
- No changes
## semantic_map_publisher
- No changes
## semantic_map_to_2d
- No changes
## strands_sweep_registration
- No changes
