### PR TITLE
strands_morse: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9726,7 +9726,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.1.3-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.1.2-0`
## strands_morse

```
* Merge pull request #135 <https://github.com/strands-project/strands_morse/issues/135> from cdondrup/human_summer_school
  Adding bl environment containing human
* Adding fast modes.
* Adding bl_human environment
* Adding openni support to bl environment
* Moving static transform publisher for mht environment from morse launch file to nav launch file.
* Fixing wrong rotation in static transform publisher and increasing publishing rate to prevent tf warnings.
* Adding specific bl launch file
* Merge pull request #134 <https://github.com/strands-project/strands_morse/issues/134> from Jailander/summer_school
  Adding Summer School Location simulation
* adding navigation launch file and maps for UOL B&L simulation
* Adding Summer School Location simulation
* Contributors: Christian Dondrup, Jaime Pulido Fentanes, Marc Hanheide
```
