### PR TITLE
v4r_ros_wrappers: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10625,7 +10625,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/v4r_ros_wrappers.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/strands-project/v4r_ros_wrappers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4r_ros_wrappers` to `0.0.3-0`:
- upstream repository: https://github.com/strands-project/v4r_ros_wrappers.git
- release repository: https://github.com/strands-project-releases/v4r_ros_wrappers.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.2-0`
## camera_srv_definitions

```
* added message_runtime and missing message generation
* Contributors: Marc Hanheide
```
## camera_tracker
- No changes
## classifier_srv_definitions

```
* added message_runtime and missing message generation
* Contributors: Marc Hanheide
```
## multiview_object_recognizer
- No changes
## object_classifier
- No changes
## object_perception_msgs
- No changes
## recognition_srv_definitions

```
* added message_runtime and missing message generation
* Contributors: Marc Hanheide
```
## segmentation
- No changes
## segmentation_srv_definitions

```
* added message_runtime and missing message generation
* Contributors: Marc Hanheide
```
## singleview_object_recognizer

```
* disbale c++11 as PCL 1.7 cannot handle it
* Contributors: Marc Hanheide
```
## v4r_ros_wrappers
- No changes
