### PR TITLE
metapackages: 0.0.13-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4596,7 +4596,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/metapackages.git
-      version: 0.0.12-0
+      version: 0.0.13-0
     source:
       type: git
       url: https://github.com/strands-project/metapackages.git


### PR DESCRIPTION
Increasing version of package(s) in repository `metapackages` to `0.0.13-0`:
- upstream repository: https://github.com/strands-project/metapackages.git
- release repository: https://github.com/strands-project-releases/metapackages.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.12-0`
## strands_base
- No changes
## strands_desktop
- No changes
## strands_extras
- No changes
## strands_robot
- No changes
