### PR TITLE
v4r: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10623,7 +10623,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/v4r.git
-      version: 1.0.4-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/v4r.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4r` to `1.0.5-0`:
- upstream repository: https://github.com/strands-project/v4r.git
- release repository: https://github.com/strands-project-releases/v4r.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `1.0.4-0`
## v4r
- No changes
