### PR TITLE
laser_filtering: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -4143,10 +4143,19 @@ repositories:
       version: hydro-devel
     status: maintained
   laser_filtering:
+    release:
+      packages:
+      - laser_filtering
+      - map_laser
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/laser_filtering.git
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/laser_filtering.git
       version: hydro_devel
+    status: maintained
   laser_filters:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `laser_filtering` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/laser_filtering.git
- release repository: https://github.com/strands-project-releases/laser_filtering.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## laser_filtering
- No changes
## map_laser

```
* Indigo Update, 10 queue size, pep8
* PEP8 Fixes
* don't make invalid ranges valid
* don't try to calculate with NaN
* Contributors: Aaron Blasdel, v4hn
```
