### PR TITLE
v4r_ros_wrappers: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10665,7 +10665,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/v4r_ros_wrappers.git
-      version: 0.0.4-0
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/v4r_ros_wrappers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4r_ros_wrappers` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/v4r_ros_wrappers.git
- release repository: https://github.com/strands-project-releases/v4r_ros_wrappers.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.12`
- previous version for package: `0.0.4-0`
## camera_srv_definitions
- No changes
## camera_tracker

```
* reverted last change
  as it is needed here, it turns out.
* Update CMakeLists.txt
* Contributors: Marc Hanheide
```
## classifier_srv_definitions
- No changes
## multiview_object_recognizer
- No changes
## object_classifier
- No changes
## object_perception_msgs
- No changes
## recognition_srv_definitions
- No changes
## segmentation
- No changes
## segmentation_srv_definitions
- No changes
## singleview_object_recognizer

```
* default was *very* specific and shouldn't be
  This confused a lot of people as the component simply throws a boost::filesystem error when the directory doesn't exist. Here, we should not define a default, but force people to actually define the argument, as it is a required one.
* Contributors: Marc Hanheide
```
## v4r_ros_wrappers
- No changes
