### PR TITLE
v4r: 1.0.6-11 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10642,7 +10642,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/v4r.git
-      version: 1.0.5-0
+      version: 1.0.6-11
     source:
       type: git
       url: https://github.com/strands-project/v4r.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4r` to `1.0.6-11`:
- upstream repository: https://github.com/strands-project/v4r.git
- release repository: https://github.com/strands-project-releases/v4r.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.5-0`
## v4r

```
* Merge pull request #23 <https://github.com/strands-project/v4r/issues/23> from strands-project/mergeLAMOR
  Merge lamor
* merged lamor STRANDS
* Merge branch 'master' of github.com:strands-project/v4r into mergeLAMOR
* Merge branch 'master' of rgit.acin.tuwien.ac.at:root/v4r into mergeLAMOR
* added default param for printParams in MV recognizer
  other minor changes
* Update Readme.md
* hopefully fixes bug in ourcvfh with different pcl versions
  view_all_point_clouds_in_folder can now also save images to disk
* Merge branch 'master' into 'master'
  Master
  See merge request !35
* catch SIFT FLANN exception when updating model database
* flann idx now configurable
* Merge branch 'master' into 'master'
  Master
  See merge request !34
* Merge branch 'master' into 'master'
  Master
  See merge request !33
* Contributors: Marc Hanheide, Thomas Fäulhammer
```
