### PR TITLE
whycon: 1.2.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11337,10 +11337,16 @@ repositories:
       version: hydro-devel
     status: maintained
   whycon:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/whycon.git
+      version: 1.2.2-0
     source:
       type: git
       url: https://github.com/LCAS/whycon.git
       version: master
+    status: developed
   wifi_ddwrt:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `whycon` to `1.2.2-0`:
- upstream repository: https://github.com/LCAS/whycon.git
- release repository: https://github.com/strands-project-releases/whycon.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## whycon

```
* visualization
* some service or whatever package
* angles package
* tf added
* Image geometry added
* Camera info package
* Contributors: Tom Krajnik
```
