### PR TITLE
whycon: 1.2.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11341,7 +11341,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/whycon.git
-      version: 1.2.2-0
+      version: 1.2.3-0
     source:
       type: git
       url: https://github.com/LCAS/whycon.git


### PR DESCRIPTION
Increasing version of package(s) in repository `whycon` to `1.2.3-0`:
- upstream repository: https://github.com/LCAS/whycon.git
- release repository: https://github.com/strands-project-releases/whycon.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.2.2-0`
## whycon

```
* Merge pull request #2 <https://github.com/LCAS/whycon/issues/2> from LCAS/marc-hanheide-patch-1
  added missing install targets
* added missing install targets
* Contributors: Marc Hanheide
```
