### PR TITLE
v4r: 1.0.11-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11045,7 +11045,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/v4r.git
-      version: 1.0.10-0
+      version: 1.0.11-5
     source:
       type: git
       url: https://github.com/strands-project/v4r.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4r` to `1.0.11-5`:
- upstream repository: https://github.com/strands-project/v4r.git
- release repository: https://github.com/strands-project-releases/v4r.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.10-0`
## v4r

```
* Merge pull request #34 <https://github.com/strands-project/v4r/issues/34> from strands-project/remove_tomgine
  temporary remove Tomgine and everything related to it (i.e. object cl…
* also comment computeCentroid in single-view object recognizer
* comment computeCentroid to silence error
* temporary remove Tomgine and everything related to it (i.e. object classification)
* Contributors: Thomas Fäulhammer
```
