### PR TITLE
v4r_ros_wrappers: 0.0.6-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11082,7 +11082,6 @@ repositories:
       - camera_tracker
       - classifier_srv_definitions
       - multiview_object_recognizer
-      - object_classifier
       - object_perception_msgs
       - recognition_srv_definitions
       - segmentation
@@ -11092,7 +11091,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/v4r_ros_wrappers.git
-      version: 0.0.5-0
+      version: 0.0.6-5
     source:
       type: git
       url: https://github.com/strands-project/v4r_ros_wrappers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4r_ros_wrappers` to `0.0.6-5`:
- upstream repository: https://github.com/strands-project/v4r_ros_wrappers.git
- release repository: https://github.com/strands-project-releases/v4r_ros_wrappers.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.5-0`
## camera_srv_definitions
- No changes
## camera_tracker

```
* fixed namespace and include issues to fit V4R Version 1.0.11
* Contributors: Thomas Fäulhammer
```
## classifier_srv_definitions
- No changes
## multiview_object_recognizer

```
* fixed namespace and include issues to fit V4R Version 1.0.11
* Contributors: Thomas Fäulhammer
```
## object_perception_msgs
- No changes
## recognition_srv_definitions
- No changes
## segmentation
- No changes
## segmentation_srv_definitions
- No changes
## singleview_object_recognizer

```
* fixed namespace and include issues to fit V4R Version 1.0.11
* Contributors: Thomas Fäulhammer
```
## v4r_ros_wrappers
- No changes
