### PR TITLE
strands_morse: 0.1.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10271,7 +10271,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.1.3-0
+      version: 0.1.4-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.1.4-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.3-0`
## strands_morse

```
* Merge pull request #138 <https://github.com/strands-project/strands_morse/issues/138> from Jailander/move-base-arena
  adding move_base arena simulation
* Merge pull request #140 <https://github.com/strands-project/strands_morse/issues/140> from Jailander/witham_warf
  adding witham warf simulation
* changing camera
* adding drawers to blender simulation
* adding topological maps for all tests
* removing static transformation publisher and adding TF publisher on morse script
* Merge pull request #1 <https://github.com/strands-project/strands_morse/issues/1> from cdondrup/move-base-arena
  Adding fast wireframe mode for move base arena
* Adding fast wireframe mode for move base arena
* removing from this branch as they are in another pull request
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_morse into move-base-arena
* adding witham warf simulation
* splitting topological map into maps per test
* Merge branch 'edge-mapping' of https://github.com/Jailander/strands_morse into move-base-arena
* Merge pull request #139 <https://github.com/strands-project/strands_morse/issues/139> from strands-project/marc-hanheide-patch-2
  scitos_ptu was missing from deps
* scitos_ptu was missing from deps
* adding move_base arena simulation
* Improved Blender file
* UOL witham warf simulation
* Contributors: Christian Dondrup, Jaime Pulido Fentanes, Marc Hanheide
```
