### PR TITLE
strands_perception_people: 1.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10330,6 +10330,7 @@ repositories:
       - odometry_to_motion_matrix
       - opencv_warco
       - people_tracker_emulator
+      - people_tracker_filter
       - perception_people_launch
       - strands_head_orientation
       - strands_perception_people
@@ -10339,7 +10340,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 1.1.8-0
+      version: 1.2.0-0
     source:
       type: git
       url: https://github.com/strands-project/strands_perception_people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `1.2.0-0`:
- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.8-0`
## bayes_people_tracker

```
* Adding missing tf include
* Renaming directories in bayes_people_tracker. Before this the header files were not installed correctly.
  Also creating a a new cals dedictaed to creating the human marker for rviz. Will be used in people_tracker_filter.
* Merge pull request #169 <https://github.com/strands-project/strands_perception_people/issues/169> from cdondrup/velo_message
  Adding the velocity of detect people to PeopleTracker message
* Adding mygrate.py and missing install targets.
* Adding rule to migrate rosbags to new message format
* Adding velocities of detected people as a geometry_msgs/Vector3 to PeopleTracker message
* Contributors: Christian Dondrup, Marc Hanheide
```
## bayes_people_tracker_logging

```
* Logging component logs the filtered output now.
* Adding mygrate.py and missing install targets.
* Contributors: Christian Dondrup
```
## detector_msg_to_pose_array
- No changes
## ground_plane_estimation
- No changes
## human_trajectory
- No changes
## mdl_people_tracker
- No changes
## odometry_to_motion_matrix
- No changes
## opencv_warco
- No changes
## people_tracker_emulator

```
* Merge pull request #169 <https://github.com/strands-project/strands_perception_people/issues/169> from cdondrup/velo_message
  Adding the velocity of detect people to PeopleTracker message
* Adding option to create new uuid in emulator via service call.
* Smoothing velocity and ensuring the same publishing rate as for the people tracker.
* Using new PeopleTracker message in emulator + code clean-up
* Contributors: Christian Dondrup, Marc Hanheide
```
## people_tracker_filter

```
* Updating CMakeLists and package.xml
* Adding velocities to filter.
* Actually publishing people message now.
* Removing occupancy grid utils dependency by copying the relevant functions.
* Updating launch file to make the map server optional. Also adding more arguments.
* 

    * People tracker now has the same functionality as all the other components meaning that it lies dormant until someone subscribes to any of its topics.
    * Filter now filters all the people_tracker topics.
    * Using new people_marker class to create human markers for filtered tracks.

* Adding try catch for cell out of bounds
* Adding people tracker filter based on a map.
* Contributors: Christian Dondrup
* Updating CMakeLists and package.xml
* Adding velocities to filter.
* Actually publishing people message now.
* Removing occupancy grid utils dependency by copying the relevant functions.
* Updating launch file to make the map server optional. Also adding more arguments.
* 

    * People tracker now has the same functionality as all the other components meaning that it lies dormant until someone subscribes to any of its topics.
    * Filter now filters all the people_tracker topics.
    * Using new people_marker class to create human markers for filtered tracks.

* Adding try catch for cell out of bounds
* Adding people tracker filter based on a map.
* Contributors: Christian Dondrup
```
## perception_people_launch

```
* Adding new parameters to readme file.
* Adding people tracker filter to overall launch file. Is started by default using the map provided on /map.
  If not subscribed to, will not use any CPU.
* Contributors: Christian Dondrup
```
## strands_head_orientation
- No changes
## strands_perception_people
- No changes
## upper_body_detector

```
* Make UBD viz padding-aware and not share ROS buffer.
* UBD viz only works for rgb8 images.
* Contributors: lucasb-eyer
```
## vision_people_logging
- No changes
## visual_odometry
- No changes
