### PR TITLE
mongodb_store: 0.1.20-1 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5007,7 +5007,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.18-1
+      version: 0.1.20-1
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.20-1`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.18-1`
## mongodb_log
- No changes
## mongodb_store

```
* Added some extra robustness to mongodb_play. This means latch does not need to be defined as in #123 <https://github.com/strands-project/mongodb_store/issues/123>.
* Added corrected wait pattern to replicator node start-up
* making mongod using smaller files
  consuming less space. The journals are massive, to the point they can't be created on jenkins.
* Contributors: Marc Hanheide, Nick Hawes
```
## mongodb_store_msgs
- No changes
