### PR TITLE
Revert "Revert "v4r: 1.1.0-5 in 'indigo/distribution.yaml' [bloom]""

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11318,7 +11318,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/v4r.git
-      version: 1.0.11-5
+      version: 1.1.0-5
     source:
       type: git
       url: https://github.com/strands-project/v4r.git


### PR DESCRIPTION
Reverts strands-project/rosdistro#570

I'm an idiot. V4R was all good...
