### PR TITLE
v4r: 1.1.1-5 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11318,7 +11318,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/v4r.git
-      version: 1.1.0-5
+      version: 1.1.1-5
     source:
       type: git
       url: https://github.com/strands-project/v4r.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4r` to `1.1.1-5`:
- upstream repository: https://github.com/strands-project/v4r.git
- release repository: https://github.com/strands-project-releases/v4r.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.1.0-5`
## v4r

```
* Merge pull request #37 <https://github.com/strands-project/v4r/issues/37> from strands-project/add_glm_run_dependency
  add glm also as run dependency
* add glm also as run dependency
* Contributors: Thomas Fäulhammer
```
