### PR TITLE
v4r_ros_wrappers: 0.0.8-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11342,7 +11342,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/v4r_ros_wrappers.git
-      version: 0.0.7-0
+      version: 0.0.8-0
     source:
       type: git
       url: https://github.com/strands-project/v4r_ros_wrappers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4r_ros_wrappers` to `0.0.8-0`:
- upstream repository: https://github.com/strands-project/v4r_ros_wrappers.git
- release repository: https://github.com/strands-project-releases/v4r_ros_wrappers.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.7-0`
## camera_srv_definitions
- No changes
## camera_tracker
- No changes
## classifier_srv_definitions
- No changes
## multiview_object_recognizer
- No changes
## object_classifier

```
* added segmentation_srv_definitions as dependency
* Contributors: Marc Hanheide
```
## object_perception_msgs
- No changes
## recognition_srv_definitions
- No changes
## segment_and_classify
- No changes
## segmentation
- No changes
## segmentation_srv_definitions
- No changes
## singleview_object_recognizer
- No changes
## v4r_ros_wrappers
- No changes
