### PR TITLE
strands_morse: 0.1.6-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10446,7 +10446,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.1.5-0
+      version: 0.1.6-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.1.6-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.5-0`
## strands_morse

```
* Merge pull request #145 <https://github.com/strands-project/strands_morse/issues/145> from cdondrup/indigo-devel
  Adding more tests to mba environment
* Adding more test maps.
  Removing morse human from test simulation.
* Adding new topo maps for tests with passive objects as obstacles.
* Adding a wireframe map containing human and a mba test environment which also contains passive objects as obstacles.
* Adding new obstacle belnd models
* Contributors: Christian Dondrup, Marc Hanheide
```
