### PR TITLE
data_compression: 0.1.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -1685,7 +1685,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/data_compression.git
-      version: 0.0.10-0
+      version: 0.1.2-0
     source:
       type: git
       url: https://github.com/strands-project/data_compression.git


### PR DESCRIPTION
Increasing version of package(s) in repository `data_compression` to `0.1.2-0`:
- upstream repository: https://github.com/strands-project/data_compression.git
- release repository: https://github.com/strands-project-releases/data_compression.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.10-0`
## catkinized_libav
- No changes
## libav_image_transport
- No changes
## mongodb_openni_compression
- No changes
## rosbag_openni_compression
- No changes
