### PR TITLE
v4r_ros_wrappers: 0.0.11-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11685,6 +11685,8 @@ repositories:
       - multiview_object_recognizer
       - object_classifier
       - object_perception_msgs
+      - object_tracker
+      - object_tracker_srv_definitions
       - recognition_srv_definitions
       - segment_and_classify
       - segmentation
@@ -11694,7 +11696,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/v4r_ros_wrappers.git
-      version: 0.0.10-0
+      version: 0.0.11-0
     source:
       type: git
       url: https://github.com/strands-project/v4r_ros_wrappers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4r_ros_wrappers` to `0.0.11-0`:
- upstream repository: https://github.com/strands-project/v4r_ros_wrappers.git
- release repository: https://github.com/strands-project-releases/v4r_ros_wrappers.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.10-0`
## camera_srv_definitions
- No changes
## camera_tracker

```
* added object tracker
* adapt
* Merge branch 'fix_missing_include'
* use pcl_conversion from ROS package
  create camera tracker header
* Contributors: Thomas Fäulhammer
```
## classifier_srv_definitions
- No changes
## multiview_object_recognizer

```
* updated readme and launch files
* adapt
* adapt_to_new_v4r_interfaces!
* use pcl_conversion from ROS package
  create camera tracker header
* Contributors: Thomas Fäulhammer
```
## object_classifier

```
* adapt
* Contributors: Thomas Fäulhammer
```
## object_perception_msgs
- No changes
## object_tracker

```
* use old pcl grabber to be conform with PCL version 1.7
* made the version the same...
  ...  as in all other packages in this repository. This is needed for prepare_release to work. See https://lcas.lincoln.ac.uk/jenkins/job/prepare-release/382/console for an example where this had failed.
* added object tracker
* Contributors: Marc Hanheide, Thomas Fäulhammer
* use old pcl grabber to be conform with PCL version 1.7
* made the version the same...
  ...  as in all other packages in this repository. This is needed for prepare_release to work. See https://lcas.lincoln.ac.uk/jenkins/job/prepare-release/382/console for an example where this had failed.
* added object tracker
* Contributors: Marc Hanheide, Thomas Fäulhammer
```
## object_tracker_srv_definitions

```
* and another package version not initialised
  before a repository can be released, *all* package.xml need to have the same version or [prepare-release](https://lcas.lincoln.ac.uk/jenkins/job/prepare-release/383/console) is doomed to fail :-(
* added object tracker
* Contributors: Marc Hanheide, Thomas Fäulhammer
* and another package version not initialised
  before a repository can be released, *all* package.xml need to have the same version or [prepare-release](https://lcas.lincoln.ac.uk/jenkins/job/prepare-release/383/console) is doomed to fail :-(
* added object tracker
* Contributors: Marc Hanheide, Thomas Fäulhammer
```
## recognition_srv_definitions
- No changes
## segment_and_classify

```
* use old pcl grabber to be conform with PCL version 1.7
* Contributors: Thomas Fäulhammer
```
## segmentation

```
* adapt
* adapt_to_new_v4r_interfaces!
* Contributors: Thomas Fäulhammer
```
## segmentation_srv_definitions
- No changes
## singleview_object_recognizer

```
* updated readme and launch files
* adapt
* adapt_to_new_v4r_interfaces!
* use pcl_conversion from ROS package
  create camera tracker header
* Contributors: Thomas Fäulhammer
```
## v4r_ros_wrappers

```
* added segment_and_classify to metapackage
* Contributors: Marc Hanheide
```
