### PR TITLE
strands_hri: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10755,7 +10755,10 @@ repositories:
       - bellbot_action_server
       - bellbot_gui
       - bellbot_scheduler
+      - hrsi_launch
       - hrsi_representation
+      - hrsi_state_prediction
+      - hrsi_velocity_costmaps
       - strands_gazing
       - strands_hri
       - strands_hri_launch
@@ -10767,7 +10770,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_hri.git
-      version: 0.0.13-0
+      version: 0.1.0-0
     source:
       type: git
       url: https://github.com/strands-project/strands_hri.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_hri` to `0.1.0-0`:
- upstream repository: https://github.com/strands-project/strands_hri.git
- release repository: https://github.com/strands-project-releases/strands_hri.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.13-0`
## bellbot_action_server

```
* [bellbot] adding voice_output to install targets
* Removed a print
* Adding ability to incorporate text published on topics.
* Adding voice_output to launch file, removing a print.
* [bellbot_action_server] Adding voice output
  Listening to state publisher and saying sentence definded in config file. Text can be said at start or end of the state. See config file for examples.
* Contributors: Christian Dondrup
```
## bellbot_gui

```
* Merge pull request #128 <https://github.com/strands-project/strands_hri/issues/128> from strands-project/json
  now uses json instead of simplejson
* publish human-readable destination on /bellbot_gui/destination
* now uses json instead of simplejson
* [bellbot_gui] Removed faulty import
* Contributors: Christian Dondrup, Marc Hanheide
```
## bellbot_scheduler
- No changes
## hrsi_launch

```
* Creating hrsi_launch package that start everything necessary to run the velocity costmaps approach using the particle filter classification.
* Contributors: Christian Dondrup
* Creating hrsi_launch package that start everything necessary to run the velocity costmaps approach using the particle filter classification.
* Contributors: Christian Dondrup
```
## hrsi_representation

```
* Updating install targets for hrsi_representation and removing test due to completely changed output and message type, the rosbag used for the test does not contain the right data. Will have to record new test data.
* Online_qtc_creator nor publishes the original string coming out of the qsr_lib.
  Creating qtc states for human-robot and human-robot's goal
* Not transforming goal anymore
* adding goal republisher.
* Creating qtc relations between robot-human and robot_goal-human in online creator. Using this to learn mappings from observations to robot behaviour and for finally working particle filtering.
* Adjusted tests for new functionalities and migrated bag file to new people message
* More bug fixes in online creator, adjusting file writer.
* Adapting offline creator to qsr_lib 0.2
* Adding max buffer size
  only adding new points if they are different
  adding possible restriction of QSR generation angle.
* Adapting online_qtc_creator to new qsr_lib format of version 0.2
* Changing default distance for qtcbc_argprobd
* Adding qtcbc_argprobd to online qtc creator
* 

    * Renaming hrsi_prediction package to hrsi_velocity_costmaps
    * Including QTCc states
    * Removed prediction part
    * Online qtc creator now also uses argprobd to publish distance values:
    * int: intimate space
    * per: personal space
    * soc: social space
    * pub: public space
    * Creating hrsi_state_prediction package that currently only uses a very simple model as a proof of concept.

* Adding the ability of only publishing the latest qtc state.
* Merge pull request #136 <https://github.com/strands-project/strands_hri/issues/136> from cdondrup/purge
  [hrsi_representation] Adding the ability of only publishing the latest qtc state.
* Adding the ability of only publishing the latest qtc state.
* Returning correct timestamp form online_qtc_creator
* Default param value should not be higher than max
  duh...
* Not using rosrun anymore for test
* Fixing broken install target
* Adding a test for the offline converter
* Creating an offline conversion script to read csv files and turn them into json qtc files.
* Removed hmm creator and renamed train to offline_qtc_creator.
  Also made some changes to only convert to qtc and attempt to train an hmm.
* Since this has been created before the actual merge of the qsr_lib changes, final adjustments had to be made.
* smoothing rate is not part of the parameters dictionary.
* Using new dynamic_args feature of qtc and qsr lib for parameter specification.
* Removing unnecessary prints.
* Adding correct smoothing and unittest
* Contributors: Christian Dondrup, Marc Hanheide
```
## hrsi_state_prediction

```
* state_predictor now uses new particle filter in qsr_prob_rep instead of own implementation.
* Removing unnecessary dynamic reconfigure and service options to load models.
* Removing hacky particle filter
* Publishing the result of the pf
* Adding a service to reset the filter bank of the particle filter. Creates a new filter even for previously observed humans.
* Making model dir a parameter and removing the simple rules instantiation.
* adding goal republisher.
* Creating qtc relations between robot-human and robot_goal-human in online creator. Using this to learn mappings from observations to robot behaviour and for finally working particle filtering.
* Adding more simple prediction models, using dyn reconf, making particle filter work... somehow.
* Adding simple particle filter based state prediction of qtcbc
* Adding prediction based on qtcbcs_argprobd to state predictor
* 

    * Renaming hrsi_prediction package to hrsi_velocity_costmaps
    * Including QTCc states
    * Removed prediction part
    * Online qtc creator now also uses argprobd to publish distance values:
    * int: intimate space
    * per: personal space
    * soc: social space
    * pub: public space
    * Creating hrsi_state_prediction package that currently only uses a very simple model as a proof of concept.

* Contributors: Christian Dondrup
* state_predictor now uses new particle filter in qsr_prob_rep instead of own implementation.
* Removing unnecessary dynamic reconfigure and service options to load models.
* Removing hacky particle filter
* Publishing the result of the pf
* Adding a service to reset the filter bank of the particle filter. Creates a new filter even for previously observed humans.
* Making model dir a parameter and removing the simple rules instantiation.
* adding goal republisher.
* Creating qtc relations between robot-human and robot_goal-human in online creator. Using this to learn mappings from observations to robot behaviour and for finally working particle filtering.
* Adding more simple prediction models, using dyn reconf, making particle filter work... somehow.
* Adding simple particle filter based state prediction of qtcbc
* Adding prediction based on qtcbcs_argprobd to state predictor
* 

    * Renaming hrsi_prediction package to hrsi_velocity_costmaps
    * Including QTCc states
    * Removed prediction part
    * Online qtc creator now also uses argprobd to publish distance values:
    * int: intimate space
    * per: personal space
    * soc: social space
    * pub: public space
    * Creating hrsi_state_prediction package that currently only uses a very simple model as a proof of concept.

* Contributors: Christian Dondrup
```
## hrsi_velocity_costmaps

```
* velocity costmap server publishes to /velocity_costmap now and takes the qsr_lib style qtc strings as input.
  Also updating cmake and package file.
* Creating qtc relations between robot-human and robot_goal-human in online creator. Using this to learn mappings from observations to robot behaviour and for finally working particle filtering.
* Minor changes: no more gradual costs in qtcb
* Running velocity costmap creation loop only if not '?' given.
* Adding gradual costs to velocity costmaps. This way not all of the free area has 0 costs but forces the robot to stay in the middle of the area if possible given the other costs.
* 

    * Renaming hrsi_prediction package to hrsi_velocity_costmaps
    * Including QTCc states
    * Removed prediction part
    * Online qtc creator now also uses argprobd to publish distance values:
    * int: intimate space
    * per: personal space
    * soc: social space
    * pub: public space
    * Creating hrsi_state_prediction package that currently only uses a very simple model as a proof of concept.

* Contributors: Christian Dondrup
* velocity costmap server publishes to /velocity_costmap now and takes the qsr_lib style qtc strings as input.
  Also updating cmake and package file.
* Creating qtc relations between robot-human and robot_goal-human in online creator. Using this to learn mappings from observations to robot behaviour and for finally working particle filtering.
* Minor changes: no more gradual costs in qtcb
* Running velocity costmap creation loop only if not '?' given.
* Adding gradual costs to velocity costmaps. This way not all of the free area has 0 costs but forces the robot to stay in the middle of the area if possible given the other costs.
* 

    * Renaming hrsi_prediction package to hrsi_velocity_costmaps
    * Including QTCc states
    * Removed prediction part
    * Online qtc creator now also uses argprobd to publish distance values:
    * int: intimate space
    * per: personal space
    * soc: social space
    * pub: public space
    * Creating hrsi_state_prediction package that currently only uses a very simple model as a proof of concept.

* Contributors: Christian Dondrup
```
## strands_gazing
- No changes
## strands_hri
- No changes
## strands_hri_launch
- No changes
## strands_human_aware_navigation

```
* Moving loaded parameters to correct namespace
* Adding site param file param
* Adding the custom dynamic reconfigure parameters to human_aware wrapper.
  @lucasb-eyer to test
* Contributors: Christian Dondrup
```
## strands_human_following
- No changes
## strands_interaction_behaviours
- No changes
## strands_simple_follow_me
- No changes
## strands_visualise_speech
- No changes
