### PR TITLE
v4r_ros_wrappers: 0.0.12-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11757,7 +11757,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/v4r_ros_wrappers.git
-      version: 0.0.11-0
+      version: 0.0.12-0
     source:
       type: git
       url: https://github.com/strands-project/v4r_ros_wrappers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4r_ros_wrappers` to `0.0.12-0`:
- upstream repository: https://github.com/strands-project/v4r_ros_wrappers.git
- release repository: https://github.com/strands-project-releases/v4r_ros_wrappers.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.11-0`
## camera_srv_definitions
- No changes
## camera_tracker

```
* add c++11 definition
* Contributors: Thomas Fäulhammer
```
## classifier_srv_definitions
- No changes
## multiview_object_recognizer

```
* add c++11 definition
* use new parameter parsing option inside V4R library
* add OpenCV libs to multi-view cmake file
* Contributors: Thomas Fäulhammer
```
## object_classifier

```
* add c++11 definition
* Contributors: Thomas Fäulhammer
```
## object_perception_msgs
- No changes
## object_tracker

```
* add c++11 definition
* remove c++11 definition
* Contributors: Thomas Fäulhammer
```
## object_tracker_srv_definitions
- No changes
## recognition_srv_definitions
- No changes
## segment_and_classify
- No changes
## segmentation

```
* add c++11 definition
* Contributors: Thomas Fäulhammer
```
## segmentation_srv_definitions
- No changes
## singleview_object_recognizer

```
* add c++11 definition
* use new parameter parsing option inside V4R library
* Contributors: Thomas Fäulhammer
```
## v4r_ros_wrappers
- No changes
