### PR TITLE
strands_systems: 0.1.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10904,7 +10904,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_systems.git
-      version: 0.0.12-0
+      version: 0.1.0-0
   strands_ui:
     release:
       packages:


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_systems` to `0.1.0-0`:
- upstream repository: https://github.com/strands-project/strands_systems.git
- release repository: https://github.com/strands-project-releases/strands_systems.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.12-0`
## strands_bringup

```
* add default to no_go_map
* Expose the PTU device as argument so it can be set on commandline.
* Add openni2_launch dependency.
* Enable depth registration on head_xtion.
* Switch to openni2_launch for cameras.
* Adding position injection parameter
* Adding respawn flag to strands_robot.launch
* Merge branch 'indigo-devel' of http://github.com/strands-project/strands_systems into indigo-devel
* Adding human_aware_navigation launch file to strands_navigation.launch
* Contributors: Bruno Lacerda, Chris Burbridge, Christian Dondrup, lucasb-eyer
```
