### PR TITLE
strands_movebase: 0.0.22-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10788,7 +10788,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_movebase.git
-      version: 0.0.21-0
+      version: 0.0.22-0
     source:
       type: git
       url: https://github.com/strands-project/strands_movebase.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_movebase` to `0.0.22-0`:
- upstream repository: https://github.com/strands-project/strands_movebase.git
- release repository: https://github.com/strands-project-releases/strands_movebase.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.21-0`
## calibrate_chest

```
* Fixed bug
* Added an option to calibrate and publish at the same time
* Added install target for calibration server
* Contributors: Nils Bore
```
## movebase_state_service
- No changes
## param_loader
- No changes
## strands_description

```
* Adjusted chest camera x direction
* Contributors: Nils Bore
```
## strands_movebase

```
* remove scitos_2d_nav dependency. add amcl dependency
* Merge branch 'indigo-devel' of https://github.com/bfalacerda/strands_movebase into indigo-devel
* adding default="" for no_go_map
* renaming obstacles.launch to pointcloud_processing.launch
* new footprint + stop loading stuff from scitos_2d_nav
* proper value for aggressive costmap reset distance
* Switched to the nodelet version in the obstacles launch file
* Added install targets
* Added a new nodelet class to make the subsampling more efficient
* old params
* new params
* param changes to dwa
* Contributors: Bruno Lacerda, Nils Bore
```
## strands_navfn
- No changes
