### PR TITLE
strands_perception_people: 1.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10839,7 +10839,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 1.2.0-0
+      version: 1.2.1-0
     source:
       type: git
       url: https://github.com/strands-project/strands_perception_people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `1.2.1-0`:
- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.2.0-0`
## bayes_people_tracker
- No changes
## bayes_people_tracker_logging
- No changes
## detector_msg_to_pose_array
- No changes
## ground_plane_estimation

```
* Changing default topic name for use with openni2
* Contributors: Christian Dondrup
```
## human_trajectory
- No changes
## mdl_people_tracker
- No changes
## odometry_to_motion_matrix
- No changes
## opencv_warco
- No changes
## people_tracker_emulator
- No changes
## people_tracker_filter
- No changes
## perception_people_launch

```
* Changing default topic name for use with openni2
* Contributors: Christian Dondrup
```
## strands_head_orientation
- No changes
## strands_perception_people
- No changes
## upper_body_detector

```
* Making the bbox red again.
* Changing default topic name for use with openni2
* Contributors: Christian Dondrup
```
## vision_people_logging

```
* Changing default topic name for use with openni2
* Contributors: Christian Dondrup
```
## visual_odometry

```
* Changing default topic name for use with openni2
* Contributors: Christian Dondrup
```
