### PR TITLE
strands_navigation: 0.0.39-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10811,7 +10811,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.38-0
+      version: 0.0.39-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.39-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.38-0`
## emergency_behaviours
- No changes
## joy_map_saver
- No changes
## message_store_map_switcher
- No changes
## monitored_navigation
- No changes
## nav_goals_generator
- No changes
## pose_initialiser
- No changes
## strands_navigation
- No changes
## strands_navigation_msgs

```
* Impossible tests now require the navigation to fail on its own accord
  Currently, the impossible tests, i.e., blocking the way or the final node, require that the graceful death attempt is successful, meaning that the robot is able to navigate back to start after the navigation to end failed. With this PR, a new field for the service is added, giving feedback if the navigation timed out or if it failed on its own accord. Impossible tests are therefore only passed, if the navigation failed without timing out and if graceful death was successful.
* Contributors: Christian Dondrup
```
## topological_logging_manager
- No changes
## topological_navigation

```
* removing annoying print
* print warning when no route to node
* Impossible tests now require the navigation to fail on its own accord
  Currently, the impossible tests, i.e., blocking the way or the final node, require that the graceful death attempt is successful, meaning that the robot is able to navigate back to start after the navigation to end failed. With this PR, a new field for the service is added, giving feedback if the navigation timed out or if it failed on its own accord. Impossible tests are therefore only passed, if the navigation failed without timing out and if graceful death was successful.
* now execute policy server when it can't reach the position of the final node
* If the path or final waypoint is completely blocked the test will succeed if the robot is able to fail gracefully.
* Removing support for dynamic human tests. These have been postponed in simulation.
* Adding more tests with humans blocking waypoints.
* making sure topological navigation fails when it should
* Adding description of new tests and how to create a topo map that uses the passive morse objects added to readme.
* Change in test files assuming that maps always are prefixed with mb_test and just append a number for the correct one.
* 

    * Adding obstacle nodes
    * Making sure that position injection worked
    * Adding untested support for dynamic human tests by playing a bag file and positioning the human correctly.
    * Other minor improvements

* Using new mba_test builder script for simulation to also include passive objects as obstacles.
* Update README.md
* Contributors: Christian Dondrup, Jaime Pulido Fentanes, Marc Hanheide
```
## topological_utils

```
* removing prints and repeated node
* Fixes in topological utils
* Contributors: Jaime Pulido Fentanes
```
