### PR TITLE
scitos_drivers: 0.1.9-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10088,7 +10088,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/scitos_drivers.git
-      version: 0.1.8-0
+      version: 0.1.9-0
     source:
       type: git
       url: https://github.com/strands-project/scitos_drivers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_drivers` to `0.1.9-0`:
- upstream repository: https://github.com/strands-project/scitos_drivers.git
- release repository: https://github.com/strands-project-releases/scitos_drivers.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.8-0`
## flir_pantilt_d46

```
* Expose the "port" parameter in the launchfile.
* Contributors: lucasb-eyer
```
## scitos_bringup
- No changes
## scitos_drivers
- No changes
## scitos_mira

```
* changed ros::Time::now() to actual mira timestamp for the messaged taken from MIRA and published into ROS
* Contributors: g_gemignani
```
## scitos_pc_monitor
- No changes
