### PR TITLE
v4r_ros_wrappers: 0.1.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11747,6 +11747,7 @@ repositories:
       - incremental_object_learning_srv_definitions
       - multiview_object_recognizer
       - object_classifier
+      - object_detection_and_tracking
       - object_perception_msgs
       - object_tracker
       - object_tracker_srv_definitions
@@ -11759,7 +11760,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/v4r_ros_wrappers.git
-      version: 0.1.2-0
+      version: 0.1.3-0
     source:
       type: git
       url: https://github.com/strands-project/v4r_ros_wrappers.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4r_ros_wrappers` to `0.1.3-0`:
- upstream repository: https://github.com/strands-project/v4r_ros_wrappers.git
- release repository: https://github.com/strands-project-releases/v4r_ros_wrappers.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.2-0`
## camera_srv_definitions
- No changes
## camera_tracker
- No changes
## classifier_srv_definitions
- No changes
## incremental_object_learning
- No changes
## incremental_object_learning_srv_definitions
- No changes
## multiview_object_recognizer
- No changes
## object_classifier
- No changes
## object_detection_and_tracking

```
* update version number to match others
* remove c++11 construct
* added object_detection_and_tracking module
  removed action for object presence checking as it is outdated
* Contributors: Thomas Fäulhammer
* update version number to match others
* remove c++11 construct
* added object_detection_and_tracking module
  removed action for object presence checking as it is outdated
* Contributors: Thomas Fäulhammer
```
## object_perception_msgs
- No changes
## object_tracker

```
* added object_detection_and_tracking module
  removed action for object presence checking as it is outdated
* Contributors: Thomas Fäulhammer
```
## object_tracker_srv_definitions

```
* added object_detection_and_tracking module
  removed action for object presence checking as it is outdated
* Contributors: Thomas Fäulhammer
```
## recognition_srv_definitions
- No changes
## segment_and_classify
- No changes
## segmentation
- No changes
## segmentation_srv_definitions
- No changes
## singleview_object_recognizer

```
* remove action server.py from install list
* added object_detection_and_tracking module
  removed action for object presence checking as it is outdated
* Contributors: Thomas Fäulhammer
```
## v4r_ros_wrappers
- No changes
