### PR TITLE
v4r: 1.4.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11735,7 +11735,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/v4r.git
-      version: 1.4.0-0
+      version: 1.4.1-0
     source:
       type: git
       url: https://github.com/strands-project/v4r.git


### PR DESCRIPTION
Increasing version of package(s) in repository `v4r` to `1.4.1-0`:
- upstream repository: https://github.com/strands-project/v4r.git
- release repository: https://github.com/strands-project-releases/v4r.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.4.0-0`
## v4r

```
* Merge pull request #58 <https://github.com/strands-project/v4r/issues/58> from strands-project/fix1
  initialize counter variable
* initialize counter variable
* Merge pull request #57 <https://github.com/strands-project/v4r/issues/57> from strands-project/remove_c+11_from_header
  remove c++11 construct in header file
* remove c++11 construct in header file
* Merge pull request #56 <https://github.com/strands-project/v4r/issues/56> from strands-project/fix1
  Fix1
* add siftgpu as optional dependency in RTMT
* copy uniform_sampling files from PCL 1.7.2 to make V4R also compile on PCL 1.8
* updated RTMT noise model parameters
* Merge remote-tracking branch 'v4r_root/master'
* Merge branch 'dynamic_object_learning' into 'master'
  Dynamic object learning
  See merge request !50
* Merge branch 'master' into 'master'
  Master
  See merge request !49
* Contributors: Thomas Fäulhammer
```
