### PR TITLE
fremen: 0.2.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2547,6 +2547,8 @@ repositories:
   fremen:
     release:
       packages:
+      - fremen2dgrid
+      - fremenarray
       - fremengrid
       - fremenserver
       - frenap
@@ -2554,7 +2556,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/fremen.git
-      version: 0.1.3-0
+      version: 0.2.0-0
     source:
       type: git
       url: https://github.com/strands-project/fremen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fremen` to `0.2.0-0`:
- upstream repository: https://github.com/strands-project/fremen.git
- release repository: https://github.com/strands-project-releases/fremen.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.3-0`
## fremen2dgrid

```
* Towards topometric mapping FreMen
* First attempt to represent recency
* Added estimate entropy action
* ROS-compatible FreMen grid
* Contributors: Tom Krajnik
```
## fremenarray

```
* Added estimate entropy action
* FremenArray: FreMEn for 2D grids.
* Contributors: Tom Krajnik
```
## fremengrid
- No changes
## fremenserver

```
* Checking length of the correct arrays
* Extended by adding an 'addvalue' action, which accepts floating points at input. I recommend to normalize the floats to [0-1].
* Redundand variable 'order' removed from CFrelement
* View action
* forecastEntropy action
* forecastEntropy action
* Contributors: Tom Krajnik
```
## frenap
- No changes
## froctomap
- No changes
