### PR TITLE
strands_morse: 0.1.7-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10808,7 +10808,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_morse.git
-      version: 0.1.6-0
+      version: 0.1.7-0
     source:
       type: git
       url: https://github.com/strands-project/strands_morse.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_morse` to `0.1.7-0`:
- upstream repository: https://github.com/strands-project/strands_morse.git
- release repository: https://github.com/strands-project-releases/strands_morse.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.1.6-0`
## strands_morse

```
* Merge pull request #147 <https://github.com/strands-project/strands_morse/issues/147> from cburbridge/patch-2
  Update simulated laser pose to match real robot.
* Update simulated laser pose to match real robot.
  Closes https://github.com/strands-project/strands_morse/issues/143.
* Merge pull request #146 <https://github.com/strands-project/strands_morse/issues/146> from Jailander/move-base-arena
  topological map change
* switching nodes in mb_test8
* Merge branch 'indigo-devel' of https://github.com/strands-project/strands_morse into move-base-arena
* Merge pull request #142 <https://github.com/strands-project/strands_morse/issues/142> from Jailander/move-base-arena
  adding person blender files for witham warf simulation
* Merge branch 'indigo-devel' of https://github.com/cdondrup/strands_morse into move-base-arena
* updating models
* adding person blender files for witham warf simulation
* Contributors: Chris Burbridge, Jaime Pulido Fentanes, Marc Hanheide
```
