### PR TITLE
strands_social: 0.0.16-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10928,7 +10928,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_social.git
-      version: 0.0.15-0
+      version: 0.0.16-0
     source:
       type: git
       url: https://github.com/strands-project/strands_social.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_social` to `0.0.16-0`:
- upstream repository: https://github.com/strands-project/strands_social.git
- release repository: https://github.com/strands-project-releases/strands_social.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.15-0`
## card_image_tweet
- No changes
## datamatrix_read
- No changes
## fake_camera_effects
- No changes
## image_branding

```
* added missing install targets
* Contributors: Jailander
```
## social_card_reader

```
* Merge pull request #47 <https://github.com/strands-project/strands_social/issues/47> from gestom/hydro-devel
  Social card reader parameters reconfigurable.
* Social card reader parameters reconfigurable.
* Contributors: Marc Hanheide, Tom Krajnik
```
## strands_social
- No changes
## strands_tweets
- No changes
