### PR TITLE
strands_ui: 0.0.26-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10950,12 +10950,13 @@ repositories:
       - music_player
       - pygame_managed_player
       - sound_player_server
+      - strands_control_ui
       - strands_ui
       - strands_webserver
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_ui.git
-      version: 0.0.25-0
+      version: 0.0.26-0
     source:
       type: git
       url: https://github.com/strands-project/strands_ui.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_ui` to `0.0.26-0`:
- upstream repository: https://github.com/strands-project/strands_ui.git
- release repository: https://github.com/strands-project-releases/strands_ui.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.25-0`
## mary_tts

```
* added IP4 help
* Contributors: Marc Hanheide
```
## mongodb_media_server
- No changes
## music_player
- No changes
## pygame_managed_player
- No changes
## sound_player_server
- No changes
## strands_control_ui

```
* version fixed
* changed to throttled topic
* added task definitions for review
* several layout changes and fixes
* changed name
* made task configurable
* fixed protocol
* made mjpeg use host variable
* auto-scale map and layout changes
* minor fix for the review IPs
* tidied up, translated to English, and made it all configurable
* renaming done
* Add 'strands_control_ui/' from commit '82b3889a06c6e08d44ba8e2460288f1ce9b67e46'
  git-subtree-dir: strands_control_ui
  git-subtree-mainline: 9b4565d8840d276ac32f3d3253b91cef04dda040
  git-subtree-split: 82b3889a06c6e08d44ba8e2460288f1ce9b67e46
* Contributors: Marc Hanheide
* version fixed
* changed to throttled topic
* added task definitions for review
* several layout changes and fixes
* changed name
* made task configurable
* fixed protocol
* made mjpeg use host variable
* auto-scale map and layout changes
* minor fix for the review IPs
* tidied up, translated to English, and made it all configurable
* renaming done
* Add 'strands_control_ui/' from commit '82b3889a06c6e08d44ba8e2460288f1ce9b67e46'
  git-subtree-dir: strands_control_ui
  git-subtree-mainline: 9b4565d8840d276ac32f3d3253b91cef04dda040
  git-subtree-split: 82b3889a06c6e08d44ba8e2460288f1ce9b67e46
* Contributors: Marc Hanheide
```
## strands_ui
- No changes
## strands_webserver
- No changes
