### PR TITLE
wifiscanner: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12122,10 +12122,16 @@ repositories:
       version: hydro-devel
     status: maintained
   wifiscanner:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/wifiscanner.git
+      version: 0.0.1-0
     source:
       type: git
       url: https://github.com/LCAS/wifiscanner.git
       version: master
+    status: developed
   willow_maps:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `wifiscanner` to `0.0.1-0`:
- upstream repository: https://github.com/LCAS/wifiscanner.git
- release repository: https://github.com/strands-project-releases/wifiscanner.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## wifiscanner

```
* making it ready for release with install targets and correct maintainer
* added wifiscanner working
* first ros commit
* Initial commit
* Contributors: Marc Hanheide
```
