### PR TITLE
strands_movebase: 0.0.23-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10825,7 +10825,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_movebase.git
-      version: 0.0.22-0
+      version: 0.0.23-0
     source:
       type: git
       url: https://github.com/strands-project/strands_movebase.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_movebase` to `0.0.23-0`:
- upstream repository: https://github.com/strands-project/strands_movebase.git
- release repository: https://github.com/strands-project-releases/strands_movebase.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.22-0`
## calibrate_chest
- No changes
## movebase_state_service
- No changes
## param_loader
- No changes
## strands_description
- No changes
## strands_movebase

```
* Added proper install target for subsampling nodelet
* Contributors: Nils Bore
```
## strands_navfn
- No changes
