### PR TITLE
strands_perception_people: 1.3.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10890,10 +10890,11 @@ repositories:
       - upper_body_detector
       - vision_people_logging
       - visual_odometry
+      - wheelchair_detector
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 1.3.0-0
+      version: 1.3.1-0
     source:
       type: git
       url: https://github.com/strands-project/strands_perception_people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `1.3.1-0`:
- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.3.0-0`
## bayes_people_tracker
- No changes
## bayes_people_tracker_logging
- No changes
## detector_msg_to_pose_array
- No changes
## ground_plane_estimation
- No changes
## human_trajectory
- No changes
## mdl_people_tracker
- No changes
## odometry_to_motion_matrix
- No changes
## opencv_warco
- No changes
## people_tracker_emulator
- No changes
## people_tracker_filter
- No changes
## perception_people_launch
- No changes
## strands_head_orientation
- No changes
## strands_perception_people
- No changes
## upper_body_detector
- No changes
## vision_people_logging
- No changes
## visual_odometry
- No changes
## wheelchair_detector

```
* Added install target.
* Fixed a typo in the package.xml
* Fixed version
* Added some more info to the README file.
* Added a quick readme for the wheelchair detector.
* Initial commit of a wheelchair detection dummy node.
  This node currently only published a pose array for every scan filled with dummy detections.
  It is only here for interface defenitions and integration purposes.
* Contributors: Alexander Hermans
* Added install target.
* Fixed a typo in the package.xml
* Fixed version
* Added some more info to the README file.
* Added a quick readme for the wheelchair detector.
* Initial commit of a wheelchair detection dummy node.
  This node currently only published a pose array for every scan filled with dummy detections.
  It is only here for interface defenitions and integration purposes.
* Contributors: Alexander Hermans
```
