### PR TITLE
strands_perception_people: 1.4.0-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10901,6 +10901,7 @@ repositories:
       - people_tracker_emulator
       - people_tracker_filter
       - perception_people_launch
+      - rwth_upper_body_skeleton_random_walk
       - strands_head_orientation
       - strands_perception_people
       - upper_body_detector
@@ -10910,7 +10911,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_perception_people.git
-      version: 1.3.1-0
+      version: 1.4.0-0
     source:
       type: git
       url: https://github.com/strands-project/strands_perception_people.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_perception_people` to `1.4.0-0`:
- upstream repository: https://github.com/strands-project/strands_perception_people.git
- release repository: https://github.com/strands-project-releases/strands_perception_people.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.3.1-0`
## bayes_people_tracker
- No changes
## bayes_people_tracker_logging
- No changes
## detector_msg_to_pose_array
- No changes
## ground_plane_estimation
- No changes
## human_trajectory
- No changes
## mdl_people_tracker
- No changes
## odometry_to_motion_matrix
- No changes
## opencv_warco
- No changes
## people_tracker_emulator
- No changes
## people_tracker_filter
- No changes
## perception_people_launch
- No changes
## rwth_upper_body_skeleton_random_walk

```
* rectified version number in right place
* modified file
* modified file
* modified file
* modified files
* modified files
* added install targets, Model and README file
* added the ros node for upper body skeleton
* Contributors: urafi, urfi
* rectified version number in right place
* modified file
* modified file
* modified file
* modified files
* modified files
* added install targets, Model and README file
* added the ros node for upper body skeleton
* Contributors: urafi, urfi
```
## strands_head_orientation
- No changes
## strands_perception_people
- No changes
## upper_body_detector
- No changes
## vision_people_logging
- No changes
## visual_odometry
- No changes
## wheelchair_detector
- No changes
