### PR TITLE
fremen: 0.2.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -2554,7 +2554,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/fremen.git
-      version: 0.2.0-0
+      version: 0.2.1-0
     source:
       type: git
       url: https://github.com/strands-project/fremen.git


### PR DESCRIPTION
Increasing version of package(s) in repository `fremen` to `0.2.1-0`:
- upstream repository: https://github.com/strands-project/fremen.git
- release repository: https://github.com/strands-project-releases/fremen.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.0-0`
## fremen2dgrid

```
* added nav_msgs as dependency
  fixes #21 <https://github.com/strands-project/fremen/issues/21>
* Messing with CMakeLists.txt
* nav msgs deps added
* Added missing package to the package.xml
* Contributors: Marc Hanheide, Tom Krajnik
```
## fremenarray
- No changes
## fremengrid
- No changes
## fremenserver
- No changes
## frenap
- No changes
## froctomap
- No changes
