### PR TITLE
strands_navigation: 0.0.42-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11016,7 +11016,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_navigation.git
-      version: 0.0.41-0
+      version: 0.0.42-0
     source:
       type: git
       url: https://github.com/strands-project/strands_navigation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_navigation` to `0.0.42-0`:
- upstream repository: https://github.com/strands-project/strands_navigation.git
- release repository: https://github.com/strands-project-releases/strands_navigation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.41-0`
## emergency_behaviours
- No changes
## joy_map_saver
- No changes
## message_store_map_switcher
- No changes
## monitored_navigation
- No changes
## nav_goals_generator
- No changes
## pose_initialiser
- No changes
## strands_navigation
- No changes
## strands_navigation_msgs
- No changes
## topological_logging_manager
- No changes
## topological_navigation

```
* Removing lambda function
* calling the instance does not return anything. appending to list first and the calling.
* Making localise by topic wait for the topic to be published
* Contributors: Christian Dondrup
```
## topological_utils
- No changes
