### PR TITLE
mongodb_store: 0.1.24-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -5429,7 +5429,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.22-0
+      version: 0.1.24-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.24-0`:
- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.22-0`
## mongodb_log
- No changes
## mongodb_store
- No changes
## mongodb_store_msgs
- No changes
