### PR TITLE
occupancy_grid_utils: 0.0.10-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6513,10 +6513,16 @@ repositories:
       version: master
     status: maintained
   occupancy_grid_utils:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/occupancy_grid_utils.git
+      version: 0.0.10-0
     source:
       type: git
       url: https://github.com/LCAS/occupancy_grid_utils.git
       version: indigo-devel
+    status: maintained
   ocl:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `occupancy_grid_utils` to `0.0.10-0`:
- upstream repository: https://github.com/LCAS/occupancy_grid_utils.git
- release repository: https://github.com/strands-project-releases/occupancy_grid_utils.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `null`
## occupancy_grid_utils

```
* new maintainer
* Contributors: Marc Hanheide
```
