### PR TITLE
rosplan: 0.0.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -9724,7 +9724,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/ROSPlan.git
-      version: 0.0.3-0
+      version: 0.0.4-0
     source:
       type: git
       url: https://github.com/LCAS/ROSPlan.git


### PR DESCRIPTION
Increasing version of package(s) in repository `rosplan` to `0.0.4-0`:
- upstream repository: https://github.com/LCAS/ROSPlan.git
- release repository: https://github.com/strands-project-releases/ROSPlan.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.0.3-0`
## rosplan
- No changes
## rosplan_demos
- No changes
## rosplan_dispatch_msgs
- No changes
## rosplan_interface_mapping

```
* removed ~ which is incorrectly introduced
* Contributors: Marc Hanheide
```
## rosplan_interface_movebase
- No changes
## rosplan_knowledge_base
- No changes
## rosplan_knowledge_msgs
- No changes
## rosplan_planning_system

```
* removed ~ which is incorrectly introduced
* Contributors: Marc Hanheide
```
## rosplan_rqt
- No changes
