### PR TITLE
viper: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12747,6 +12747,11 @@ repositories:
       version: indigo-devel
     status: developed
   viper:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/viper.git
+      version: 0.0.2-0
     source:
       type: git
       url: https://github.com/strands-project/viper.git


### PR DESCRIPTION
Increasing version of package(s) in repository `viper` to `0.0.2-0`:
- upstream repository: https://github.com/kunzel/viper.git
- release repository: https://github.com/strands-project-releases/viper.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## viper

```
* Install updates
* Contributors: Nick Hawes
```
