### PR TITLE
viper_ros: 0.0.2-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12757,6 +12757,17 @@ repositories:
       url: https://github.com/strands-project/viper.git
       version: master
     status: maintained
+  viper_ros:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/viper_ros.git
+      version: 0.0.2-0
+    source:
+      type: git
+      url: https://github.com/kunzel/viper_ros.git
+      version: y3
+    status: developed
   vision_opencv:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `viper_ros` to `0.0.2-0`:
- upstream repository: http://github.com/kunzel/viper_ros.git
- release repository: https://github.com/strands-project-releases/viper_ros.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## viper_ros

```
* removed application-specific dependencies
* Contributors: Nick Hawes
```
