### PR TITLE
viper_ros: 0.0.3-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -12777,7 +12777,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/viper_ros.git
-      version: 0.0.2-0
+      version: 0.0.3-0
     source:
       type: git
       url: https://github.com/kunzel/viper_ros.git


### PR DESCRIPTION
Increasing version of package(s) in repository `viper_ros` to `0.0.3-0`:
- upstream repository: http://github.com/kunzel/viper_ros.git
- release repository: https://github.com/strands-project-releases/viper_ros.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.2-0`
## viper_ros

```
* Removed specific dep
* Contributors: Nick Hawes
```
