### PR TITLE
scitos_moveit_config: 0.0.1-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10896,6 +10896,17 @@ repositories:
       url: https://github.com/strands-project/scitos_drivers.git
       version: indigo-devel
     status: developed
+  scitos_moveit_config:
+    release:
+      tags:
+        release: release/indigo/{package}/{version}
+      url: https://github.com/strands-project-releases/scitos_moveit_config.git
+      version: 0.0.1-0
+    source:
+      type: git
+      url: https://github.com/kunzel/scitos_moveit_config.git
+      version: master
+    status: developed
   screenrun:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `scitos_moveit_config` to `0.0.1-0`:
- upstream repository: https://github.com/kunzel/scitos_moveit_config.git
- release repository: https://github.com/strands-project-releases/scitos_moveit_config.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `null`
## scitos_moveit_config

```
* updated moveit config
* initial version
* Contributors: Lars Kunze
```
