### PR TITLE
strands_executive: 1.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11821,7 +11821,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_executive.git
-      version: 1.0.0-0
+      version: 1.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/strands_executive.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_executive` to `1.0.5-0`:
- upstream repository: https://github.com/strands-project/strands_executive.git
- release repository: https://github.com/strands-project-releases/strands_executive.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `1.0.0-0`
## gcal_routine
- No changes
## mdp_plan_exec
- No changes
## scheduler
- No changes
## scipoptsuite
- No changes
## sim_clock
- No changes
## strands_executive_msgs
- No changes
## strands_executive_tutorial
- No changes
## task_executor
- No changes
## wait_action
- No changes
