### PR TITLE
semantic_segmentation: 0.0.5-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -10987,7 +10987,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/semantic_segmentation.git
-      version: 0.0.1-1
+      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/strands-project/semantic_segmentation.git


### PR DESCRIPTION
Increasing version of package(s) in repository `semantic_segmentation` to `0.0.5-0`:
- upstream repository: https://github.com/strands-project/semantic_segmentation.git
- release repository: https://github.com/strands-project-releases/semantic_segmentation.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.1-1`
## semantic_segmentation
- No changes
