### PR TITLE
strands_apps: 0.2.4-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11815,11 +11815,12 @@ repositories:
       - strands_apps
       - strands_emails
       - topic_republisher
+      - topological_roslaunch
       - watchdog_node
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/strands_apps.git
-      version: 0.2.3-0
+      version: 0.2.4-0
     source:
       type: git
       url: https://github.com/strands-project/strands_apps.git


### PR DESCRIPTION
Increasing version of package(s) in repository `strands_apps` to `0.2.4-0`:
- upstream repository: https://github.com/strands-project/strands_apps.git
- release repository: https://github.com/strands-project-releases/strands_apps.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.20`
- previous version for package: `0.2.3-0`
## door_pass

```
* sorting out for release and cleaning up hopefully unnecessary import whicih was messing up other imports
* tested and adjusted door passing
* use robot talk interface for speech
* test commit
* Making sure predictions work when no stats are found
* Less prints managing unknown doors prediction
* Avoid double model creation on start-up
* Making sure models are rebuilt when fremen server is restarted
* add door prediction to launch file
* adding build temporal model action
* adding lock, using only successful passes for time modelling, maximum probability now 0.999999
* show hold the door request on the screen
* randomised speech for door pass
* changing sampling strategy and avoiding 0.0 probability
* adapting door prediction to new message format
* adding service for door prediction
* door prediction skeleton with door extraction
* Contributors: Bruno Lacerda, Jaime Pulido Fentanes, Lars Kunze, Nick Hawes, jailander
```
## marathon_reporter
- No changes
## odometry_mileage
- No changes
## pose_extractor
- No changes
## ramp_climb
- No changes
## reconfigure_inflation
- No changes
## roslaunch_axserver
- No changes
## state_checker
- No changes
## static_transform_manager
- No changes
## strands_apps
- No changes
## strands_emails
- No changes
## topic_republisher
- No changes
## topological_roslaunch

```
* Add node to trigger roslaunch_axserver based on topological node (#55 <https://github.com/strands-project/strands_apps/issues/55>)
  * Adding skeleton of topological_roslaunch node.
  * Basic tear-down at node setup working
  * Updated deps
  * Fixed setup.py and added install
* Contributors: Nick Hawes
* Add node to trigger roslaunch_axserver based on topological node (#55 <https://github.com/strands-project/strands_apps/issues/55>)
  * Adding skeleton of topological_roslaunch node.
  * Basic tear-down at node setup working
  * Updated deps
  * Fixed setup.py and added install
* Contributors: Nick Hawes
```
## watchdog_node

```
* Added an new monitor which only subscribes to a topic at an interval to perform checks.
  This closes #53 <https://github.com/strands-project/strands_apps/issues/53>.
* Contributors: Nick Hawes
```
