### PR TITLE
soma: 1.0.0-2 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -11623,17 +11623,20 @@ repositories:
   soma:
     release:
       packages:
+      - soma2_msgs
+      - soma2_trajectory
       - soma_geospatial_store
+      - soma_io
       - soma_manager
-      - soma_msgs
+      - soma_map_manager
       - soma_objects
+      - soma_pcl_segmentation
       - soma_roi_manager
-      - soma_trajectory
       - soma_utils
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/soma.git
-      version: 0.0.1-0
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/strands-project/soma.git


### PR DESCRIPTION
Increasing version of package(s) in repository `soma` to `1.0.0-2`:
- upstream repository: https://github.com/strands-project/soma.git
- release repository: https://github.com/strands-project-releases/soma.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.0.1-0`
## soma2_msgs

```
* Updated package xml files.
* Big restucture for release
* Contributors: Nick Hawes
```
## soma2_trajectory

```
* Updated package xml files.
* Latest soma2 is merged into soma fork named as soma
* Contributors: Nick Hawes, hkaraoguz
```
## soma_geospatial_store

```
* Updated package xml files.
* Contributors: Nick Hawes
```
## soma_io

```
* Updated package xml files.
* integrates latest world_state code
* integrates latest world_state code
* Contributors: Jay Young, Nick Hawes, ferdianjovan
```
## soma_manager

```
* Updated package xml files.
* Big restucture for release
* Updated structure for release.
* Fixes for building on OSX and restructure for release.
* Fixed the time based query problem by changing the field type of lowerdate and upperdate to uint64
* fix for header dependency
* Try to solve query manager lock down while ros::shutdown. Moved to launch folder under soma_manager
* Fixed the hanging of query_manager during shutdown. Refined code for soma_roi
* Fixed issues with query manager crashing when empty fields or no data is present
* Fixed issue with empty typeids or objectsids. Updated launch file.
* Corrected msg dependencies
* Query results are returned as srv response. ROI drawing color has been set
* Listening map service is added
* Query service has been added
* Remove unnecesary folder
* Updated documentation
* Latest soma2 is merged into soma fork named as soma
* Contributors: Nick Hawes, Nils Bore, hkaraoguz
```
## soma_map_manager

```
* Updated package xml files.
* Big restucture for release
* Improving structure of soma_map_manager for release.
* Performance issue for  soma_map has been fixed
* Launch file has been updated for launching with mapname as an argument. soma_map has been updated to parse arguments correctly
* mapname argument has been added to soma_map.py for fast startup
* Updated documentation. Updated soma map
* Latest soma2 is merged into soma fork named as soma
* Contributors: Nick Hawes, hkaraoguz
```
## soma_objects

```
* Updated package xml files.
* Latest soma2 is merged into soma fork named as soma
* Contributors: Nick Hawes, hkaraoguz
```
## soma_pcl_segmentation

```
* Updated package xml files.
* soma pcl segmentation
* Contributors: Nick Hawes, Rares
```
## soma_roi_manager

```
* Updated package xml files.
* Added missing import
* Big restucture for release
* Updated structure for release.
* Fixed the hanging of query_manager during shutdown. Refined code for soma_roi
* The corruption of regions after saving and loading has been fixed
* Query results are returned as srv response. ROI drawing color has been set
* SOMA2  to SOMA name changes
* Updated documentation
* Latest soma2 is merged into soma fork named as soma
* Contributors: Nick Hawes, hkaraoguz
```
## soma_utils

```
* Updated package xml files.
* make negative/no-allowed object default
* add about text
* change color
* code re-factoring for soma roi analyzer
* ignore persons
* remove jpg files
* generate blog entries (incl. images and contour for objects)
* add soma utils package incl a simple ROI analyzer
* Remove soma_utils directory
* Contributors: Lars Kunze, Nick Hawes, hkaraoguz
```
