### PR TITLE
mongodb_store: 0.1.27-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6111,7 +6111,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.25-0
+      version: 0.1.27-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.27-0`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.21`
- previous version for package: `0.1.25-0`

## mongodb_log

- No changes

## mongodb_store

```
* Fixed if statement
* geotype of ROI has been added
* The geospatial indexing of SOMA ROI objects is added
* Contributors: Hakan
```

## mongodb_store_msgs

- No changes
