### PR TITLE
mongodb_store: 0.1.30-0 in 'indigo/distribution.yaml' [bloom]

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -6884,7 +6884,7 @@ repositories:
       tags:
         release: release/indigo/{package}/{version}
       url: https://github.com/strands-project-releases/mongodb_store.git
-      version: 0.1.29-0
+      version: 0.1.30-0
     source:
       type: git
       url: https://github.com/strands-project/mongodb_store.git


### PR DESCRIPTION
Increasing version of package(s) in repository `mongodb_store` to `0.1.30-0`:

- upstream repository: https://github.com/strands-project/mongodb_store.git
- release repository: https://github.com/strands-project-releases/mongodb_store.git
- distro file: `indigo/distribution.yaml`
- bloom version: `0.5.26`
- previous version for package: `0.1.29-0`

## mongodb_log

- No changes

## mongodb_store

```
* [package.xml] Add link to devel repository
  Without this, from [the package's wiki page](http://wiki.ros.org/mongodb_store) there's no way to tell where the repo is.
* fixing error with launching mongodb_store
* Contributors: Ferdian Jovan, Hakan, Isaac I.Y. Saito, Justin Huang
```

## mongodb_store_msgs

- No changes
