### PR TITLE
Removed strands_executive_tutorial package to fix dependencies

### DIFF
--- a/indigo/distribution.yaml
+++ b/indigo/distribution.yaml
@@ -14742,8 +14742,7 @@ repositories:
       - scheduler
       - scipoptsuite
       - sim_clock
-      - strands_executive_msgs
-      - strands_executive_tutorial
+      - strands_executive_msgs      
       - task_executor
       - wait_action
       tags:


### PR DESCRIPTION
This is to remove the package which was also removed from the repo. After this can I run the release wizard?